### PR TITLE
Update the metadata to 1.21.7

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": "*",
     "fabric-api": "*",
-    "minecraft": "1.21.6",
+    "minecraft": "1.21.7",
     "java": ">=21"
   },
   "custom": {


### PR DESCRIPTION
This was overlooked when updating the mod. Without this change, Fabric Loader will refuse to load the mod.