### PR TITLE
performance improvements

### DIFF
--- a/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
+++ b/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
@@ -68,14 +68,24 @@ public class ParallelProcessor {
         new SpscLinkedQueue<>();
     private static final Queue<Entity> pendingDespawnQueue =
         new SpscLinkedQueue<>();
-    private static final Queue<Runnable> pendingSpawnQueue =
-        new SpscLinkedQueue<>();
+    // Double-buffer for spawn work. Both produce and drain happen on the main thread,
+    // so no concurrent data structure is needed. The main thread fills spawnCollect during
+    // chunk iteration, then submitSpawnCycle swaps it with spawnSubmit and hands the full
+    // list to a pool thread. Zero drain, zero copy - just a reference swap.
+    private static ArrayList<SpawnEntry> spawnCollect = new ArrayList<>();
+    private static ArrayList<SpawnEntry> spawnSubmit = new ArrayList<>();
     private static final Queue<CompletableFuture<?>> externalTaskQueue =
         new MpscUnboundedArrayQueue<>(256);
 
-    // Lightweight record holding a world+entity pair by reference. No copying.
-    // 16-byte object header + 2 references = fits in a single cache line.
+    // Lightweight records holding references. No data copying - just pointers.
     record EntityTickEntry(ServerLevel world, Entity entity) {}
+
+    record SpawnEntry(
+        ServerLevel level,
+        LevelChunk chunk,
+        NaturalSpawner.SpawnState spawnState,
+        List<MobCategory> categories
+    ) {}
 
     public static final Set<Class<?>> BLOCKED_ENTITIES = Set.of(
         FallingBlockEntity.class,
@@ -267,41 +277,42 @@ public class ParallelProcessor {
 
         if (categories.isEmpty()) return;
 
-        // categories is typically a short immutable view from Minecraft internals.
-        // We must capture a snapshot since the caller may mutate the list after return.
-        // List.copyOf is zero-copy if the source is already an unmodifiable list (common case).
-        List<MobCategory> cats = List.copyOf(categories);
-        pendingSpawnQueue.add(() ->
-            NaturalSpawner.spawnForChunk(level, chunk, spawnState, cats)
+        // Capture a snapshot of categories since the caller may mutate the list.
+        // List.copyOf is zero-copy if the source is already unmodifiable (common case).
+        spawnCollect.add(
+            new SpawnEntry(level, chunk, spawnState, List.copyOf(categories))
         );
     }
 
     private static void submitSpawnCycle() {
-        // Drain all pending spawn work into a local collection.
-        // ConcurrentLinkedQueue.poll() is lock-free.
-        Runnable first = pendingSpawnQueue.poll();
-        if (first == null) return;
+        if (spawnCollect.isEmpty()) return;
 
+        // If the previous cycle is still running, join it instead of discarding work.
+        // In practice it should always be done - postEntityTick waits for completion -
+        // but joining guarantees we never silently drop spawn work.
         ForkJoinTask<?> prev = currentSpawnTask;
         if (prev != null && !prev.isDone()) {
-            // Previous cycle still running - discard pending work to avoid piling up
-            pendingSpawnQueue.clear();
-            return;
+            prev.quietlyJoin();
         }
 
-        // Drain remaining items
-        ArrayList<Runnable> work = new ArrayList<>();
-        work.add(first);
-        Runnable r;
-        while ((r = pendingSpawnQueue.poll()) != null) {
-            work.add(r);
-        }
+        // Swap buffers: hand the full list to the pool thread, start collecting into
+        // the (now empty) previous submit buffer. No drain, no copy, no allocation.
+        ArrayList<SpawnEntry> ready = spawnCollect;
+        spawnCollect = spawnSubmit;
+        spawnCollect.clear();
+        spawnSubmit = ready;
 
-        // Submit as a single task. Spawn work is inherently sequential per-chunk
-        // due to SpawnState mutation, so we run them serially within one pool thread.
+        // Spawn work must run serially (shared SpawnState mutation) but is offloaded
+        // to a pool thread so the main thread can proceed with entity tick submission.
         currentSpawnTask = tickPool.submit(() -> {
-            for (int i = 0, n = work.size(); i < n; i++) {
-                work.get(i).run();
+            for (int i = 0, n = ready.size(); i < n; i++) {
+                SpawnEntry s = ready.get(i);
+                NaturalSpawner.spawnForChunk(
+                    s.level(),
+                    s.chunk(),
+                    s.spawnState(),
+                    s.categories()
+                );
             }
         });
     }
@@ -465,6 +476,7 @@ public class ParallelProcessor {
         blacklistedEntity.clear();
         pendingEntityQueue.clear();
         pendingDespawnQueue.clear();
-        pendingSpawnQueue.clear();
+        spawnCollect.clear();
+        spawnSubmit.clear();
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
+++ b/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
@@ -2,6 +2,12 @@ package com.axalotl.async.common;
 
 import com.axalotl.async.common.config.AsyncConfig;
 import com.axalotl.async.common.parallelised.utils.VanishCompat;
+import io.netty.util.internal.shaded.org.jctools.queues.MpscUnboundedArrayQueue;
+import io.netty.util.internal.shaded.org.jctools.queues.SpscLinkedQueue;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.server.MinecraftServer;
@@ -20,14 +26,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.ref.WeakReference;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.LockSupport;
-
 public class ParallelProcessor {
-    public static final Logger LOGGER = LogManager.getLogger(ParallelProcessor.class);
+
+    public static final Logger LOGGER = LogManager.getLogger(
+        ParallelProcessor.class
+    );
 
     @Getter
     @Setter
@@ -37,61 +40,106 @@ public class ParallelProcessor {
     public static final AtomicInteger currentEntities = new AtomicInteger();
     private static final Object ENTITY_ADD_LOCK = new Object();
     private static final AtomicInteger threadPoolID = new AtomicInteger();
-    private static final Set<UUID> blacklistedEntity = ConcurrentHashMap.newKeySet();
-    private static final Map<String, Set<WeakReference<Thread>>> mcThreadTracker = new ConcurrentHashMap<>();
+    private static final Set<UUID> blacklistedEntity =
+        ConcurrentHashMap.newKeySet();
     private static volatile boolean isShuttingDown = false;
 
-    private static int despawnCount = 0;
-    private static int pendingCount = 0;
+    // Thread-local flag: set to true for all threads created by our ForkJoinPool.
+    // Checked by isServerExecutionThread() - O(1) instead of streaming WeakReferences.
+    private static final ThreadLocal<Boolean> IS_ASYNC_TICK_THREAD =
+        ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     private static final int ENTITY_GRAIN = 64;
     private static final int DESPAWN_GRAIN = 128;
-    private static final int INITIAL_CAPACITY = 16384;
     private static volatile ForkJoinTask<?> currentSpawnTask;
-    private static Entity[] pendingDespawns = new Entity[4096];
-    private static Entity[] pendingEntities = new Entity[INITIAL_CAPACITY];
-    private static final ArrayList<Runnable> pendingSpawnWork = new ArrayList<>();
-    private static ServerLevel[] pendingWorlds = new ServerLevel[INITIAL_CAPACITY];
-    private static final ConcurrentLinkedQueue<CompletableFuture<?>> externalTaskQueue = new ConcurrentLinkedQueue<>();
+
+    // jctools queues from Netty's shaded bundle - specialized for our access patterns.
+    //
+    // Entity/despawn/spawn queues are SPSC: the main server tick thread is the sole
+    // producer (callEntityTick/asyncDespawn/asyncSpawnForChunk) and sole consumer
+    // (postEntityTick drains them). SpscLinkedQueue uses plain stores with StoreStore
+    // barriers - zero CAS overhead, optimal for this single-threaded collect-then-drain pattern.
+    //
+    // External task queue is MPSC: pool worker threads produce (addTask from random tick
+    // submissions), main thread consumes (postEntityTick). MpscUnboundedArrayQueue uses
+    // array-backed chunks for cache-friendly traversal with lock-free CAS on the producer
+    // side and wait-free consumption.
+    private static final Queue<EntityTickEntry> pendingEntityQueue =
+        new SpscLinkedQueue<>();
+    private static final Queue<Entity> pendingDespawnQueue =
+        new SpscLinkedQueue<>();
+    private static final Queue<Runnable> pendingSpawnQueue =
+        new SpscLinkedQueue<>();
+    private static final Queue<CompletableFuture<?>> externalTaskQueue =
+        new MpscUnboundedArrayQueue<>(256);
+
+    // Lightweight record holding a world+entity pair by reference. No copying.
+    // 16-byte object header + 2 references = fits in a single cache line.
+    record EntityTickEntry(ServerLevel world, Entity entity) {}
 
     public static final Set<Class<?>> BLOCKED_ENTITIES = Set.of(
-            FallingBlockEntity.class,
-            Shulker.class,
-            AbstractBoat.class
+        FallingBlockEntity.class,
+        Shulker.class,
+        AbstractBoat.class
     );
+
+    // Worker thread subclass that sets the ThreadLocal flag on the actual worker thread
+    // during onStart(), which runs on the worker thread itself (not the factory caller).
+    private static final class AsyncTickWorkerThread
+        extends ForkJoinWorkerThread
+    {
+
+        AsyncTickWorkerThread(ForkJoinPool pool) {
+            super(pool);
+        }
+
+        @Override
+        protected void onStart() {
+            super.onStart();
+            IS_ASYNC_TICK_THREAD.set(Boolean.TRUE);
+        }
+    }
 
     public static void setupThreadPool(int parallelism, Class<?> asyncClass) {
         isShuttingDown = false;
 
-        ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory = pool -> {
-            ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-            worker.setName("Async-Tick-Pool-Thread-" + threadPoolID.getAndIncrement());
-            registerThread("Async-Tick", worker);
-            worker.setDaemon(true);
-            worker.setPriority(Thread.NORM_PRIORITY);
-            worker.setContextClassLoader(asyncClass.getClassLoader());
-            return worker;
-        };
+        tickPool = new ForkJoinPool(
+            parallelism,
+            pool -> {
+                AsyncTickWorkerThread worker = new AsyncTickWorkerThread(pool);
+                worker.setName(
+                    "Async-Tick-Pool-Thread-" + threadPoolID.getAndIncrement()
+                );
+                worker.setDaemon(true);
+                worker.setPriority(Thread.NORM_PRIORITY);
+                worker.setContextClassLoader(asyncClass.getClassLoader());
+                return worker;
+            },
+            (t, e) ->
+                LOGGER.error(
+                    "Uncaught exception in thread {}: {}",
+                    t.getName(),
+                    e
+                ),
+            true
+        );
 
-        tickPool = new ForkJoinPool(parallelism, threadFactory, (t, e) ->
-                LOGGER.error("Uncaught exception in thread {}: {}", t.getName(), e), true);
         LOGGER.info("Initialized Pool with {} threads", parallelism);
         VanishCompat.apply();
     }
 
+    // Called by UtilMixin to register Minecraft's background executor threads.
+    // We mark them via ThreadLocal so isServerExecutionThread() returns true for
+    // any thread involved in async tick work. The poolName parameter is ignored -
+    // all registered threads are treated equally.
     public static void registerThread(String poolName, Thread thread) {
-        mcThreadTracker
-                .computeIfAbsent(poolName, key -> ConcurrentHashMap.newKeySet())
-                .add(new WeakReference<>(thread));
-    }
-
-    private static boolean isThreadInPool(Thread thread) {
-        return mcThreadTracker.getOrDefault("Async-Tick", Set.of()).stream()
-                .map(WeakReference::get)
-                .anyMatch(thread::equals);
+        // No-op: threads from our own pool are marked in AsyncTickWorkerThread.onStart().
+        // External threads registered here don't need the flag since they aren't
+        // part of our async tick pool. Keeping this method for mixin compatibility.
     }
 
     public static boolean isServerExecutionThread() {
-        return isThreadInPool(Thread.currentThread());
+        return IS_ASYNC_TICK_THREAD.get();
     }
 
     public static void callEntityTick(ServerLevel world, Entity entity) {
@@ -105,36 +153,36 @@ public class ParallelProcessor {
             return;
         }
 
-        int idx = pendingCount;
-        if (idx >= pendingEntities.length) {
-            int newCap = pendingEntities.length << 1;
-            pendingWorlds = Arrays.copyOf(pendingWorlds, newCap);
-            pendingEntities = Arrays.copyOf(pendingEntities, newCap);
-        }
-        pendingWorlds[idx] = world;
-        pendingEntities[idx] = entity;
-        pendingCount = idx + 1;
+        pendingEntityQueue.add(new EntityTickEntry(world, entity));
     }
 
     public static boolean shouldTickSynchronously(Entity entity) {
-        if (entity.level().isClientSide()) {
-            return true;
-        }
+        // Ordered cheapest-to-most-expensive checks.
+        // Config.disabled is a simple volatile boolean read.
+        if (AsyncConfig.disabled) return true;
 
-        UUID entityId = entity.getUUID();
-        boolean requiresSyncTick = AsyncConfig.disabled ||
-                entity instanceof Projectile ||
-                entity instanceof AbstractMinecart ||
-                entity instanceof ServerPlayer ||
-                BLOCKED_ENTITIES.contains(entity.getClass()) ||
-                blacklistedEntity.contains(entityId) ||
-                AsyncConfig.isEntitySynchronized(EntityType.getKey(entity.getType()));
+        // instanceof checks are JIT-optimized to type tag comparisons (single branch)
+        if (entity instanceof ServerPlayer) return true;
+        if (entity instanceof Projectile) return true;
+        if (entity instanceof AbstractMinecart) return true;
 
-        if (requiresSyncTick) {
-            return true;
-        }
+        // Client-side check - should never happen on server but guard anyway
+        if (entity.level().isClientSide()) return true;
 
-        return entity.portalProcess != null;
+        // Class identity check against small immutable set (hash lookup)
+        if (BLOCKED_ENTITIES.contains(entity.getClass())) return true;
+
+        // Portal check - simple null check on a field, very cheap
+        if (entity.portalProcess != null) return true;
+
+        // UUID-based blacklist check - only now do we call getUUID() which may allocate.
+        // The blacklist is typically empty, so the contains() call is O(1) on empty set.
+        if (blacklistedEntity.contains(entity.getUUID())) return true;
+
+        // Config lookup - may involve string hashing. Most expensive check, goes last.
+        return AsyncConfig.isEntitySynchronized(
+            EntityType.getKey(entity.getType())
+        );
     }
 
     public static Object getEntityAddLock() {
@@ -142,14 +190,13 @@ public class ParallelProcessor {
     }
 
     static final class EntityTickBatch extends RecursiveAction {
-        private final ServerLevel[] worlds;
-        private final Entity[] entities;
+
+        private final EntityTickEntry[] entries;
         private final int from;
         private final int to;
 
-        EntityTickBatch(ServerLevel[] worlds, Entity[] entities, int from, int to) {
-            this.worlds = worlds;
-            this.entities = entities;
+        EntityTickBatch(EntityTickEntry[] entries, int from, int to) {
+            this.entries = entries;
             this.from = from;
             this.to = to;
         }
@@ -159,19 +206,21 @@ public class ParallelProcessor {
             int size = to - from;
             if (size <= ENTITY_GRAIN) {
                 for (int i = from; i < to; i++) {
-                    worlds[i].tickNonPassenger(entities[i]);
+                    EntityTickEntry e = entries[i];
+                    e.world().tickNonPassenger(e.entity());
                 }
             } else {
                 int mid = (from + to) >>> 1;
                 invokeAll(
-                        new EntityTickBatch(worlds, entities, from, mid),
-                        new EntityTickBatch(worlds, entities, mid, to)
+                    new EntityTickBatch(entries, from, mid),
+                    new EntityTickBatch(entries, mid, to)
                 );
             }
         }
     }
 
     static final class DespawnBatch extends RecursiveAction {
+
         private final Entity[] entities;
         private final int from;
         private final int to;
@@ -192,69 +241,82 @@ public class ParallelProcessor {
             } else {
                 int mid = (from + to) >>> 1;
                 invokeAll(
-                        new DespawnBatch(entities, from, mid),
-                        new DespawnBatch(entities, mid, to)
+                    new DespawnBatch(entities, from, mid),
+                    new DespawnBatch(entities, mid, to)
                 );
             }
         }
     }
 
     public static void asyncSpawnForChunk(
-            ServerLevel level,
-            LevelChunk chunk,
-            NaturalSpawner.SpawnState spawnState,
-            List<MobCategory> categories
+        ServerLevel level,
+        LevelChunk chunk,
+        NaturalSpawner.SpawnState spawnState,
+        List<MobCategory> categories
     ) {
-        if (!chunk.loaded) {
-            return;
-        }
+        if (!chunk.loaded) return;
 
-        if (isShuttingDown || AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) {
+        if (
+            isShuttingDown ||
+            AsyncConfig.disabled ||
+            !AsyncConfig.enableAsyncSpawn
+        ) {
             NaturalSpawner.spawnForChunk(level, chunk, spawnState, categories);
             return;
         }
 
-        if (categories.isEmpty()) {
-            return;
-        }
+        if (categories.isEmpty()) return;
 
-        List<MobCategory> categoriesCopy = List.copyOf(categories);
-        pendingSpawnWork.add(() -> NaturalSpawner.spawnForChunk(level, chunk, spawnState, categoriesCopy));
+        // categories is typically a short immutable view from Minecraft internals.
+        // We must capture a snapshot since the caller may mutate the list after return.
+        // List.copyOf is zero-copy if the source is already an unmodifiable list (common case).
+        List<MobCategory> cats = List.copyOf(categories);
+        pendingSpawnQueue.add(() ->
+            NaturalSpawner.spawnForChunk(level, chunk, spawnState, cats)
+        );
     }
 
     private static void submitSpawnCycle() {
-        if (pendingSpawnWork.isEmpty()) {
-            return;
-        }
+        // Drain all pending spawn work into a local collection.
+        // ConcurrentLinkedQueue.poll() is lock-free.
+        Runnable first = pendingSpawnQueue.poll();
+        if (first == null) return;
 
         ForkJoinTask<?> prev = currentSpawnTask;
         if (prev != null && !prev.isDone()) {
-            pendingSpawnWork.clear();
+            // Previous cycle still running - discard pending work to avoid piling up
+            pendingSpawnQueue.clear();
             return;
         }
 
-        Runnable[] work = pendingSpawnWork.toArray(new Runnable[0]);
-        pendingSpawnWork.clear();
+        // Drain remaining items
+        ArrayList<Runnable> work = new ArrayList<>();
+        work.add(first);
+        Runnable r;
+        while ((r = pendingSpawnQueue.poll()) != null) {
+            work.add(r);
+        }
 
+        // Submit as a single task. Spawn work is inherently sequential per-chunk
+        // due to SpawnState mutation, so we run them serially within one pool thread.
         currentSpawnTask = tickPool.submit(() -> {
-            for (Runnable task : work) {
-                task.run();
+            for (int i = 0, n = work.size(); i < n; i++) {
+                work.get(i).run();
             }
         });
     }
 
     public static void asyncDespawn(Entity entity) {
-        if (isShuttingDown || AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) {
+        if (
+            isShuttingDown ||
+            AsyncConfig.disabled ||
+            !AsyncConfig.enableAsyncSpawn
+        ) {
             entity.checkDespawn();
             return;
         }
 
-        int idx = despawnCount;
-        if (idx >= pendingDespawns.length) {
-            pendingDespawns = Arrays.copyOf(pendingDespawns, pendingDespawns.length << 1);
-        }
-        pendingDespawns[idx] = entity;
-        despawnCount = idx + 1;
+        pendingDespawnQueue.add(entity);
     }
 
     public static void addTask(CompletableFuture<?> future) {
@@ -266,47 +328,70 @@ public class ParallelProcessor {
 
         submitSpawnCycle();
 
+        // --- Drain entity queue into array for RecursiveAction subdivision ---
+        // poll()-based drain is safe even if another thread adds concurrently.
+        // RecursiveAction needs random access for splitting, so we collect to an array.
         ForkJoinTask<?> entityTask = null;
+        int entityCount = 0;
+        EntityTickEntry[] entityBatch = null;
+
+        {
+            EntityTickEntry entry;
+            ArrayList<EntityTickEntry> buf = null;
+            while ((entry = pendingEntityQueue.poll()) != null) {
+                if (buf == null) buf = new ArrayList<>();
+                buf.add(entry);
+            }
+            if (buf != null) {
+                entityCount = buf.size();
+                entityBatch = buf.toArray(new EntityTickEntry[entityCount]);
+                currentEntities.set(entityCount);
+                entityTask = new EntityTickBatch(entityBatch, 0, entityCount);
+                tickPool.execute(entityTask);
+            }
+        }
+
+        // --- Drain despawn queue ---
         ForkJoinTask<?> despawnTask = null;
-
-        int entityCount = pendingCount;
-        pendingCount = 0;
-
-        if (entityCount > 0) {
-            currentEntities.set(entityCount);
-            entityTask = new EntityTickBatch(pendingWorlds, pendingEntities, 0, entityCount);
-            tickPool.execute(entityTask);
+        {
+            Entity entry;
+            ArrayList<Entity> buf = null;
+            while ((entry = pendingDespawnQueue.poll()) != null) {
+                if (buf == null) buf = new ArrayList<>();
+                buf.add(entry);
+            }
+            if (buf != null) {
+                int dCount = buf.size();
+                Entity[] despawnBatch = buf.toArray(new Entity[dCount]);
+                despawnTask = new DespawnBatch(despawnBatch, 0, dCount);
+                tickPool.execute(despawnTask);
+            }
         }
 
-        int dCount = despawnCount;
-        despawnCount = 0;
-
-        if (dCount > 0) {
-            despawnTask = new DespawnBatch(pendingDespawns, 0, dCount);
-            tickPool.execute(despawnTask);
-        }
-
+        // --- Drain external tasks ---
         CompletableFuture<Void> externalFuture = null;
-        List<CompletableFuture<?>> externalTasks = null;
-        CompletableFuture<?> f;
-        while ((f = externalTaskQueue.poll()) != null) {
-            if (externalTasks == null) {
-                externalTasks = new ArrayList<>();
+        {
+            CompletableFuture<?> f;
+            ArrayList<CompletableFuture<?>> externalTasks = null;
+            while ((f = externalTaskQueue.poll()) != null) {
+                if (externalTasks == null) externalTasks = new ArrayList<>();
+                externalTasks.add(f);
             }
-            externalTasks.add(f);
-        }
-        if (externalTasks != null) {
-            externalFuture = CompletableFuture.allOf(externalTasks.toArray(new CompletableFuture[0]));
+            if (externalTasks != null) {
+                externalFuture = CompletableFuture.allOf(
+                    externalTasks.toArray(CompletableFuture[]::new)
+                );
+            }
         }
 
+        // --- Wait for completion while doing useful work ---
+        // Instead of pure spin-wait, we interleave chunk source polling (which processes
+        // light updates, chunk loads, etc.) with brief parks when there's no work.
         while (true) {
-            boolean allDone = entityTask == null || entityTask.isDone();
-            if (despawnTask != null && !despawnTask.isDone()) {
-                allDone = false;
-            }
-            if (externalFuture != null && !externalFuture.isDone()) {
-                allDone = false;
-            }
+            boolean allDone =
+                (entityTask == null || entityTask.isDone()) &&
+                (despawnTask == null || despawnTask.isDone()) &&
+                (externalFuture == null || externalFuture.isDone());
 
             if (allDone) break;
 
@@ -320,13 +405,16 @@ public class ParallelProcessor {
             }
         }
 
+        // --- Join and report errors ---
         if (entityTask != null) {
             entityTask.quietlyJoin();
             if (entityTask.isCompletedAbnormally()) {
-                LOGGER.error("Entity tick batch error", entityTask.getException());
+                LOGGER.error(
+                    "Entity tick batch error",
+                    entityTask.getException()
+                );
             }
-            Arrays.fill(pendingWorlds, 0, entityCount, null);
-            Arrays.fill(pendingEntities, 0, entityCount, null);
+            // entityBatch is a local array - no need to null-fill, it's immediately GC-eligible
             currentEntities.set(0);
         }
 
@@ -335,8 +423,10 @@ public class ParallelProcessor {
             if (despawnTask.isCompletedAbnormally()) {
                 LOGGER.error("Despawn batch error", despawnTask.getException());
             }
-            Arrays.fill(pendingDespawns, 0, dCount, null);
+            // despawnBatch is local, GC-eligible immediately
         }
+
+        // Final poll to process any tasks generated during the async tick
         for (ServerLevel world : server.getAllLevels()) {
             world.getChunkSource().pollTask();
         }
@@ -350,13 +440,16 @@ public class ParallelProcessor {
             spawn.quietlyJoin();
         }
 
-        List<CompletableFuture<?>> remaining = new ArrayList<>();
+        // Drain and await remaining external tasks
+        ArrayList<CompletableFuture<?>> remaining = new ArrayList<>();
         CompletableFuture<?> f;
         while ((f = externalTaskQueue.poll()) != null) {
             remaining.add(f);
         }
         if (!remaining.isEmpty()) {
-            CompletableFuture.allOf(remaining.toArray(new CompletableFuture[0])).join();
+            CompletableFuture.allOf(
+                remaining.toArray(CompletableFuture[]::new)
+            ).join();
         }
 
         if (tickPool != null) {
@@ -370,8 +463,8 @@ public class ParallelProcessor {
 
         AsyncConfig.clearCaches();
         blacklistedEntity.clear();
-        pendingSpawnWork.clear();
-        pendingCount = 0;
-        despawnCount = 0;
+        pendingEntityQueue.clear();
+        pendingDespawnQueue.clear();
+        pendingSpawnQueue.clear();
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
+++ b/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
@@ -396,8 +396,14 @@ public class ParallelProcessor {
         }
 
         // --- Wait for completion while doing useful work ---
-        // Instead of pure spin-wait, we interleave chunk source polling (which processes
-        // light updates, chunk loads, etc.) with brief parks when there's no work.
+        // Backoff idle strategy: spin → yield → progressive park.
+        // Spin phase catches sub-microsecond completions with zero kernel involvement.
+        // Yield phase handles the 1-10us range without sleeping.
+        // Progressive park only kicks in for genuinely long waits, capping at 100us.
+        // When useful work is found (pollTask), backoff resets immediately.
+        int idleCount = 0;
+        long parkNanos = 1_000L;
+
         while (true) {
             boolean allDone =
                 (entityTask == null || entityTask.isDone()) &&
@@ -411,8 +417,18 @@ public class ParallelProcessor {
                 didWork |= world.getChunkSource().pollTask();
             }
 
-            if (!didWork) {
-                LockSupport.parkNanos(1_000L);
+            if (didWork) {
+                idleCount = 0;
+                parkNanos = 1_000L;
+            } else if (idleCount < 4) {
+                Thread.onSpinWait();
+                idleCount++;
+            } else if (idleCount < 8) {
+                Thread.yield();
+                idleCount++;
+            } else {
+                LockSupport.parkNanos(parkNanos);
+                parkNanos = Math.min(parkNanos << 1, 100_000L);
             }
         }
 

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
@@ -2,6 +2,9 @@ package com.axalotl.async.common.mixin.entity.movement;
 
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import net.minecraft.util.ClassInstanceMultiMap;
 import net.minecraft.world.level.entity.EntityAccess;
 import net.minecraft.world.level.entity.EntitySection;
@@ -10,10 +13,6 @@ import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 
 @Mixin(EntitySection.class)
 public class EntitySectionMixin<T extends EntityAccess> {
@@ -27,37 +26,22 @@ public class EntitySectionMixin<T extends EntityAccess> {
     private Visibility chunkStatus;
 
     @Unique
-    private final AtomicReference<Visibility> async$atomicStatus = new AtomicReference<>(Visibility.HIDDEN);
-
-    @Unique
-    private final Object async$storageLock = new Object();
+    private final AtomicReference<Visibility> async$atomicStatus =
+        new AtomicReference<>(Visibility.HIDDEN);
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void async$init(Class<?> clazz, Visibility status, CallbackInfo ci) {
+    private void async$init(
+        Class<?> clazz,
+        Visibility status,
+        CallbackInfo ci
+    ) {
         async$atomicStatus.set(status != null ? status : Visibility.HIDDEN);
     }
 
-    /**
-     * @author FurryMileon
-     * @reason Make add thread-safe with per-instance lock
-     */
-    @Overwrite
-    public void add(T entity) {
-        synchronized (async$storageLock) {
-            this.storage.add(entity);
-        }
-    }
-
-    /**
-     * @author FurryMileon
-     * @reason Make remove thread-safe with per-instance lock
-     */
-    @Overwrite
-    public boolean remove(T entity) {
-        synchronized (async$storageLock) {
-            return this.storage.remove(entity);
-        }
-    }
+    // add() and remove() no longer need a lock here.
+    // ClassInstanceMultiMap (the backing storage) already has a per-instance lock
+    // via ClassInstanceMultiMapMixin. Having a second lock at the section level
+    // just doubled the contention cost for zero safety gain.
 
     /**
      * @author FurryMileon
@@ -82,9 +66,6 @@ public class EntitySectionMixin<T extends EntityAccess> {
 
     @WrapMethod(method = "getEntities()Ljava/util/stream/Stream;")
     private Stream<T> getEntities(Operation<Stream<T>> original) {
-        return storage.stream()
-                .filter(Objects::nonNull)
-                .toList()
-                .stream();
+        return storage.stream().filter(Objects::nonNull).toList().stream();
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
@@ -66,6 +66,8 @@ public class EntitySectionMixin<T extends EntityAccess> {
 
     @WrapMethod(method = "getEntities()Ljava/util/stream/Stream;")
     private Stream<T> getEntities(Operation<Stream<T>> original) {
-        return storage.stream().filter(Objects::nonNull).toList().stream();
+        // storage is backed by CopyOnWriteArrayList (via ClassInstanceMultiMapMixin),
+        // so .stream() already iterates a snapshot. No need to copy into a second list.
+        return storage.stream().filter(Objects::nonNull);
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionStorageMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionStorageMixin.java
@@ -6,6 +6,9 @@ import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
+import java.util.Objects;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import net.minecraft.world.level.entity.EntityAccess;
 import net.minecraft.world.level.entity.EntitySection;
 import net.minecraft.world.level.entity.EntitySectionStorage;
@@ -13,10 +16,6 @@ import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Objects;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 @Mixin(value = EntitySectionStorage.class)
 public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
@@ -34,15 +33,21 @@ public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
     @Shadow
     public abstract LongStream getExistingSectionPositionsInChunk(long pos);
 
-
     @Unique
     private final Object async$Lock = new Object();
 
     @WrapMethod(method = "getOrCreateSection")
-    private EntitySection<T> getOrCreateSection(long pos, Operation<EntitySection<T>> original) {
+    private EntitySection<T> getOrCreateSection(
+        long pos,
+        Operation<EntitySection<T>> original
+    ) {
         EntitySection<T> existing = this.sections.get(pos);
         if (existing != null) return existing;
+        // Double-checked: another thread may have created the section between our
+        // get() and acquiring the lock. Re-check inside the lock to avoid duplicates.
         synchronized (async$Lock) {
+            existing = this.sections.get(pos);
+            if (existing != null) return existing;
             return original.call(pos);
         }
     }
@@ -54,11 +59,14 @@ public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
     }
 
     @WrapMethod(method = "getExistingSectionsInChunk")
-    private Stream<EntitySection<T>> getExistingSections(long pos, Operation<Stream<EntitySection<T>>> original) {
+    private Stream<EntitySection<T>> getExistingSections(
+        long pos,
+        Operation<Stream<EntitySection<T>>> original
+    ) {
         return this.getExistingSectionPositionsInChunk(pos)
-                .mapToObj(this.sections::get)
-                .filter(Objects::nonNull)
-                .toList()
-                .stream();
+            .mapToObj(this.sections::get)
+            .filter(Objects::nonNull)
+            .toList()
+            .stream();
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/NaturalSpawnerMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/NaturalSpawnerMixin.java
@@ -2,9 +2,13 @@ package com.axalotl.async.common.mixin.entity.spawn;
 
 import com.axalotl.async.common.ParallelProcessor;
 import com.axalotl.async.common.config.AsyncConfig;
+import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.ChargeEntry;
+import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.MobCapEntry;
 import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.SpawnDataCollector;
-import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.SpawnEntry;
+import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.SpawnResult;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.LocalMobCapCalculator;
@@ -16,20 +20,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 @Mixin(value = NaturalSpawner.class, priority = 900)
 public abstract class NaturalSpawnerMixin {
 
     @Inject(method = "createState", at = @At("HEAD"), cancellable = true)
     private static void async$createState(
-            int spawnableChunkCount,
-            Iterable<Entity> entities,
-            NaturalSpawner.ChunkGetter chunkGetter,
-            LocalMobCapCalculator localMobCapCalculator,
-            CallbackInfoReturnable<NaturalSpawner.SpawnState> cir
+        int spawnableChunkCount,
+        Iterable<Entity> entities,
+        NaturalSpawner.ChunkGetter chunkGetter,
+        LocalMobCapCalculator localMobCapCalculator,
+        CallbackInfoReturnable<NaturalSpawner.SpawnState> cir
     ) {
         if (AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) {
             return;
@@ -37,15 +37,22 @@ public abstract class NaturalSpawnerMixin {
         if (ParallelProcessor.tickPool == null) {
             return;
         }
-        cir.setReturnValue(async$createStateParallel(spawnableChunkCount, entities, chunkGetter, localMobCapCalculator));
+        cir.setReturnValue(
+            async$createStateParallel(
+                spawnableChunkCount,
+                entities,
+                chunkGetter,
+                localMobCapCalculator
+            )
+        );
     }
 
     @Unique
     private static NaturalSpawner.SpawnState async$createStateParallel(
-            int spawnableChunkCount,
-            Iterable<Entity> entities,
-            NaturalSpawner.ChunkGetter chunkGetter,
-            LocalMobCapCalculator localMobCapCalculator
+        int spawnableChunkCount,
+        Iterable<Entity> entities,
+        NaturalSpawner.ChunkGetter chunkGetter,
+        LocalMobCapCalculator localMobCapCalculator
     ) {
         List<Entity> entityList;
         if (entities instanceof List<Entity> list) {
@@ -57,31 +64,44 @@ public abstract class NaturalSpawnerMixin {
 
         if (entityList.isEmpty()) {
             return new NaturalSpawner.SpawnState(
-                    spawnableChunkCount,
-                    new Object2IntOpenHashMap<>(),
-                    new PotentialCalculator(),
-                    localMobCapCalculator
+                spawnableChunkCount,
+                new Object2IntOpenHashMap<>(),
+                new PotentialCalculator(),
+                localMobCapCalculator
             );
         }
 
-        ConcurrentLinkedQueue<SpawnEntry> results = new ConcurrentLinkedQueue<>();
         Entity[] entityArray = entityList.toArray(new Entity[0]);
 
-        SpawnDataCollector task = new SpawnDataCollector(entityArray, chunkGetter, results, 0, entityArray.length);
-        ParallelProcessor.tickPool.invoke(task);
+        // Tree-merge parallel collection: each leaf accumulates locally,
+        // results merge up the fork-join tree. No shared mutable state.
+        SpawnResult result = ParallelProcessor.tickPool.invoke(
+            new SpawnDataCollector(
+                entityArray,
+                chunkGetter,
+                0,
+                entityArray.length
+            )
+        );
 
-        // Sequential merge
+        // Apply results sequentially on the main thread.
+        // PotentialCalculator and LocalMobCapCalculator are not thread-safe.
         PotentialCalculator potentialCalculator = new PotentialCalculator();
-        Object2IntOpenHashMap<MobCategory> mobCounts = new Object2IntOpenHashMap<>();
-
-        for (SpawnEntry data : results) {
-            potentialCalculator.addCharge(data.pos(), data.charge());
-            if (data.isMob()) {
-                localMobCapCalculator.addMob(data.chunkPos(), data.category());
-            }
-            mobCounts.addTo(data.category(), 1);
+        for (int i = 0, n = result.charges.size(); i < n; i++) {
+            ChargeEntry c = result.charges.get(i);
+            potentialCalculator.addCharge(c.pos(), c.charge());
         }
 
-        return new NaturalSpawner.SpawnState(spawnableChunkCount, mobCounts, potentialCalculator, localMobCapCalculator);
+        for (int i = 0, n = result.mobCapEntries.size(); i < n; i++) {
+            MobCapEntry m = result.mobCapEntries.get(i);
+            localMobCapCalculator.addMob(m.chunkPos(), m.category());
+        }
+
+        return new NaturalSpawner.SpawnState(
+            spawnableChunkCount,
+            result.mobCounts,
+            potentialCalculator,
+            localMobCapCalculator
+        );
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/PotentialCalculatorMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/PotentialCalculatorMixin.java
@@ -1,15 +1,20 @@
 package com.axalotl.async.common.mixin.entity.spawn;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.world.level.PotentialCalculator;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 @Mixin(PotentialCalculator.class)
 public class PotentialCalculatorMixin {
 
+    // Plain ArrayList instead of CopyOnWriteArrayList.
+    // Charges are built sequentially on the main thread in createState(), then the
+    // PotentialCalculator is passed into SpawnState and only read during spawnForChunk().
+    // The happens-before from ForkJoinPool task submission guarantees visibility.
+    // CopyOnWriteArrayList was O(n) per addCharge (full array copy each time) = O(n²) total.
     @Shadow
-    private final List<PotentialCalculator.PointCharge> charges = new CopyOnWriteArrayList<>();
+    private final List<PotentialCalculator.PointCharge> charges =
+        new ArrayList<>();
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/server/ChunkMapMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/server/ChunkMapMixin.java
@@ -11,6 +11,13 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.RecursiveAction;
+import java.util.function.Consumer;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ChunkGenerationTask;
 import net.minecraft.server.level.ChunkHolder;
@@ -32,15 +39,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Consumer;
-
 @Mixin(value = ChunkMap.class, priority = 1500)
-public abstract class ChunkMapMixin extends SimpleRegionStorage implements ChunkHolder.PlayerProvider {
+public abstract class ChunkMapMixin
+    extends SimpleRegionStorage
+    implements ChunkHolder.PlayerProvider
+{
 
     @Shadow
     @Final
@@ -68,7 +71,13 @@ public abstract class ChunkMapMixin extends SimpleRegionStorage implements Chunk
     @Final
     ServerLevel level;
 
-    public ChunkMapMixin(RegionStorageInfo p_326109_, Path p_321582_, DataFixer p_321815_, boolean p_321788_, DataFixTypes p_321522_) {
+    public ChunkMapMixin(
+        RegionStorageInfo p_326109_,
+        Path p_321582_,
+        DataFixer p_321815_,
+        boolean p_321788_,
+        DataFixTypes p_321522_
+    ) {
         super(p_326109_, p_321582_, p_321815_, p_321788_, p_321522_);
     }
 
@@ -80,27 +89,46 @@ public abstract class ChunkMapMixin extends SimpleRegionStorage implements Chunk
     }
 
     @WrapMethod(method = "addEntity")
-    private synchronized void addEntity(Entity entity, Operation<Void> original) {
+    private synchronized void addEntity(
+        Entity entity,
+        Operation<Void> original
+    ) {
         original.call(entity);
     }
 
     @WrapMethod(method = "removeEntity")
-    private synchronized void removeEntity(Entity entity, Operation<Void> original) {
+    private synchronized void removeEntity(
+        Entity entity,
+        Operation<Void> original
+    ) {
         original.call(entity);
     }
 
     @WrapMethod(method = "releaseGeneration")
-    private synchronized void releaseGeneration(GenerationChunkHolder chunk, Operation<Void> original) {
+    private synchronized void releaseGeneration(
+        GenerationChunkHolder chunk,
+        Operation<Void> original
+    ) {
         original.call(chunk);
     }
 
-    @Inject(method = "addEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;pauseInIde(Ljava/lang/Throwable;)Ljava/lang/Throwable;"), cancellable = true)
+    @Inject(
+        method = "addEntity",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/Util;pauseInIde(Ljava/lang/Throwable;)Ljava/lang/Throwable;"
+        ),
+        cancellable = true
+    )
     private void skipThrowLoadEntity(Entity entity, CallbackInfo ci) {
         ci.cancel();
     }
 
     @WrapMethod(method = "collectSpawningChunks")
-    private void async$optimizedCollectSpawningChunks(List<LevelChunk> result, Operation<Void> original) {
+    private void async$optimizedCollectSpawningChunks(
+        List<LevelChunk> result,
+        Operation<Void> original
+    ) {
         List<ServerPlayer> players = this.level.players();
         double[] playerX = new double[players.size()];
         double[] playerZ = new double[players.size()];
@@ -142,35 +170,90 @@ public abstract class ChunkMapMixin extends SimpleRegionStorage implements Chunk
         }
     }
 
-    @WrapMethod(method = "forEachBlockTickingChunk")
-    private void forEachBlockTickingChunk(Consumer<LevelChunk> action, Operation<Void> original) {
-        if (!AsyncConfig.disabled && AsyncConfig.enableAsyncRandomTicks) {
-            // Snapshot chunk positions for thread-safe iteration
-            List<Long> keys = new ArrayList<>();
-            distanceManager.forEachEntityTickingChunk(keys::add);
+    private static final int RANDOM_TICK_GRAIN = 16;
 
-            for (long chunkPos : keys) {
-                ChunkHolder holder = visibleChunkMap.get(chunkPos);
+    @WrapMethod(method = "forEachBlockTickingChunk")
+    private void forEachBlockTickingChunk(
+        Consumer<LevelChunk> action,
+        Operation<Void> original
+    ) {
+        if (!AsyncConfig.disabled && AsyncConfig.enableAsyncRandomTicks) {
+            // Collect eligible chunks into an array for RecursiveAction subdivision.
+            // Avoids per-chunk CompletableFuture allocation and MpscQueue CAS overhead.
+            ArrayList<LevelChunk> chunks = new ArrayList<>();
+            distanceManager.forEachEntityTickingChunk(pos -> {
+                ChunkHolder holder = visibleChunkMap.get(pos);
                 if (holder != null) {
                     LevelChunk chunk = holder.getTickingChunk();
                     if (chunk != null) {
-                        CompletableFuture<Void> future = CompletableFuture.runAsync(
-                                () -> {
-                                    if (chunk.getLevel() != null) {
-                                        action.accept(chunk);
-                                    }
-                                },
-                                ParallelProcessor.tickPool
-                        ).exceptionally(e -> {
-                            ParallelProcessor.LOGGER.error("Error in async random tick", e);
-                            return null;
-                        });
-                        ParallelProcessor.addTask(future);
+                        chunks.add(chunk);
                     }
                 }
+            });
+
+            if (!chunks.isEmpty()) {
+                LevelChunk[] arr = chunks.toArray(new LevelChunk[0]);
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                ParallelProcessor.tickPool.execute(() -> {
+                    try {
+                        new RandomTickBatch(
+                            arr,
+                            0,
+                            arr.length,
+                            action
+                        ).invoke();
+                        future.complete(null);
+                    } catch (Throwable e) {
+                        future.completeExceptionally(e);
+                    }
+                });
+                ParallelProcessor.addTask(future);
             }
         } else {
             original.call(action);
+        }
+    }
+
+    static final class RandomTickBatch extends RecursiveAction {
+
+        private final LevelChunk[] chunks;
+        private final int from;
+        private final int to;
+        private final Consumer<LevelChunk> action;
+
+        RandomTickBatch(
+            LevelChunk[] chunks,
+            int from,
+            int to,
+            Consumer<LevelChunk> action
+        ) {
+            this.chunks = chunks;
+            this.from = from;
+            this.to = to;
+            this.action = action;
+        }
+
+        @Override
+        protected void compute() {
+            int size = to - from;
+            if (size <= RANDOM_TICK_GRAIN) {
+                for (int i = from; i < to; i++) {
+                    try {
+                        action.accept(chunks[i]);
+                    } catch (Throwable e) {
+                        ParallelProcessor.LOGGER.error(
+                            "Error in async random tick",
+                            e
+                        );
+                    }
+                }
+            } else {
+                int mid = (from + to) >>> 1;
+                invokeAll(
+                    new RandomTickBatch(chunks, from, mid, action),
+                    new RandomTickBatch(chunks, mid, to, action)
+                );
+            }
         }
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/parallelised/spawn/ParallelSpawnHelper.java
+++ b/common/src/main/java/com/axalotl/async/common/parallelised/spawn/ParallelSpawnHelper.java
@@ -1,18 +1,23 @@
 package com.axalotl.async.common.parallelised.spawn;
 
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.concurrent.RecursiveTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.NaturalSpawner;
+import net.minecraft.world.level.PotentialCalculator;
 import net.minecraft.world.level.biome.MobSpawnSettings;
-
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.RecursiveAction;
 
 /**
  * ForkJoinPool-native helpers for parallel createState() mob cap counting.
+ * <p>
+ * Uses a tree-merge pattern: each leaf task accumulates results locally
+ * (no shared mutable state, no CAS), then parent tasks merge child results
+ * up the fork-join tree. The final merged result is returned to the caller.
  */
 public final class ParallelSpawnHelper {
 
@@ -20,47 +25,102 @@ public final class ParallelSpawnHelper {
 
     private static final int SPAWN_GRAIN = 256;
 
-    public record SpawnEntry(BlockPos pos, MobCategory category, double charge, boolean isMob, ChunkPos chunkPos) {}
+    /**
+     * Accumulated spawn data from a subtree of entities.
+     * Built locally per leaf, merged at each fork level.
+     */
+    public static final class SpawnResult {
+
+        public final Object2IntOpenHashMap<MobCategory> mobCounts =
+            new Object2IntOpenHashMap<>();
+        public final ArrayList<ChargeEntry> charges = new ArrayList<>();
+        // Mob cap entries must be applied to LocalMobCapCalculator on the main thread
+        // since it's not thread-safe. We collect the raw data here.
+        public final ArrayList<MobCapEntry> mobCapEntries = new ArrayList<>();
+
+        public void merge(SpawnResult other) {
+            // Merge mob counts
+            for (var entry : other.mobCounts.object2IntEntrySet()) {
+                mobCounts.addTo(entry.getKey(), entry.getIntValue());
+            }
+            // Merge charges - just append, PotentialCalculator will consume them all
+            charges.addAll(other.charges);
+            // Merge mob cap entries
+            mobCapEntries.addAll(other.mobCapEntries);
+        }
+    }
+
+    public record ChargeEntry(BlockPos pos, double charge) {}
+
+    public record MobCapEntry(ChunkPos chunkPos, MobCategory category) {}
 
     /**
-     * RecursiveAction that splits entity array for work-stealing.
-     * Each leaf processes entities, calls chunkGetter.query() (O(1) via fullChunks map),
-     * and adds results to lock-free ConcurrentLinkedQueue.
+     * RecursiveTask that splits entity array for work-stealing.
+     * Each leaf accumulates results into a local SpawnResult - no shared queue,
+     * no CAS, no per-entity allocation of intermediate records.
+     * Parent tasks merge child results up the tree.
      */
-    public static final class SpawnDataCollector extends RecursiveAction {
+    public static final class SpawnDataCollector
+        extends RecursiveTask<SpawnResult>
+    {
+
         private final Entity[] entities;
         private final NaturalSpawner.ChunkGetter chunkGetter;
-        private final ConcurrentLinkedQueue<SpawnEntry> results;
         private final int from;
         private final int to;
 
-        public SpawnDataCollector(Entity[] entities, NaturalSpawner.ChunkGetter chunkGetter,
-                                  ConcurrentLinkedQueue<SpawnEntry> results, int from, int to) {
+        public SpawnDataCollector(
+            Entity[] entities,
+            NaturalSpawner.ChunkGetter chunkGetter,
+            int from,
+            int to
+        ) {
             this.entities = entities;
             this.chunkGetter = chunkGetter;
-            this.results = results;
             this.from = from;
             this.to = to;
         }
 
         @Override
-        protected void compute() {
+        protected SpawnResult compute() {
             int size = to - from;
             if (size <= SPAWN_GRAIN) {
-                for (int i = from; i < to; i++) {
-                    processEntity(entities[i]);
-                }
-            } else {
-                int mid = (from + to) >>> 1;
-                invokeAll(
-                        new SpawnDataCollector(entities, chunkGetter, results, from, mid),
-                        new SpawnDataCollector(entities, chunkGetter, results, mid, to)
-                );
+                return computeLeaf();
             }
+
+            int mid = (from + to) >>> 1;
+            SpawnDataCollector left = new SpawnDataCollector(
+                entities,
+                chunkGetter,
+                from,
+                mid
+            );
+            SpawnDataCollector right = new SpawnDataCollector(
+                entities,
+                chunkGetter,
+                mid,
+                to
+            );
+            left.fork();
+            SpawnResult rightResult = right.compute();
+            SpawnResult leftResult = left.join();
+            leftResult.merge(rightResult);
+            return leftResult;
         }
 
-        private void processEntity(Entity entity) {
-            if (entity instanceof Mob mob && (mob.isPersistenceRequired() || mob.requiresCustomPersistence())) {
+        private SpawnResult computeLeaf() {
+            SpawnResult result = new SpawnResult();
+            for (int i = from; i < to; i++) {
+                processEntity(entities[i], result);
+            }
+            return result;
+        }
+
+        private void processEntity(Entity entity, SpawnResult result) {
+            if (
+                entity instanceof Mob mob &&
+                (mob.isPersistenceRequired() || mob.requiresCustomPersistence())
+            ) {
                 return;
             }
 
@@ -71,17 +131,24 @@ public final class ParallelSpawnHelper {
 
             BlockPos blockPos = entity.blockPosition();
             chunkGetter.query(ChunkPos.asLong(blockPos), chunk -> {
-                MobSpawnSettings.MobSpawnCost cost = NaturalSpawner.getRoughBiome(blockPos, chunk)
+                MobSpawnSettings.MobSpawnCost cost =
+                    NaturalSpawner.getRoughBiome(blockPos, chunk)
                         .getMobSettings()
                         .getMobSpawnCost(entity.getType());
 
-                results.add(new SpawnEntry(
-                        blockPos,
-                        category,
-                        cost != null ? cost.charge() : 0.0,
-                        entity instanceof Mob,
-                        chunk.getPos()
-                ));
+                if (cost != null) {
+                    result.charges.add(
+                        new ChargeEntry(blockPos, cost.charge())
+                    );
+                }
+
+                result.mobCounts.addTo(category, 1);
+
+                if (entity instanceof Mob) {
+                    result.mobCapEntries.add(
+                        new MobCapEntry(chunk.getPos(), category)
+                    );
+                }
             });
         }
     }

--- a/fabric/src/main/java/com/axalotl/async/fabric/mixin/utils/ClassInstanceMultiMapMixin.java
+++ b/fabric/src/main/java/com/axalotl/async/fabric/mixin/utils/ClassInstanceMultiMapMixin.java
@@ -3,6 +3,10 @@ package com.axalotl.async.fabric.mixin.utils;
 import com.axalotl.async.common.parallelised.ConcurrentCollections;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collector;
 import net.minecraft.util.ClassInstanceMultiMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -10,16 +14,16 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collector;
-
 @Mixin(value = ClassInstanceMultiMap.class)
-public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T> {
+public abstract class ClassInstanceMultiMapMixin<
+    T
+> extends AbstractCollection<T> {
 
+    // Per-instance lock instead of static lock. The old static lock serialized every
+    // entity add/remove across ALL sections in the entire world on one object.
+    // Per-instance means sections in different chunks never contend with each other.
     @Unique
-    private static final Object async$lock = new Object();
+    private final Object async$lock = new Object();
 
     @Shadow
     private final Map<Class<?>, List<T>> byClass = new ConcurrentHashMap<>();
@@ -27,8 +31,16 @@ public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T
     @Shadow
     private final List<T> allInstances = new CopyOnWriteArrayList<>();
 
-    @ModifyArg(method = "method_15217", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"))
-    private Collector<T, ?, List<T>> overwriteCollectToList(Collector<T, ?, List<T>> collector) {
+    @ModifyArg(
+        method = "method_15217",
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"
+        )
+    )
+    private Collector<T, ?, List<T>> overwriteCollectToList(
+        Collector<T, ?, List<T>> collector
+    ) {
         return ConcurrentCollections.toList();
     }
 

--- a/neoforge/src/main/java/com/axalotl/async/neoforge/mixin/utils/ClassInstanceMultiMapMixin.java
+++ b/neoforge/src/main/java/com/axalotl/async/neoforge/mixin/utils/ClassInstanceMultiMapMixin.java
@@ -3,6 +3,10 @@ package com.axalotl.async.neoforge.mixin.utils;
 import com.axalotl.async.common.parallelised.ConcurrentCollections;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collector;
 import net.minecraft.util.ClassInstanceMultiMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -10,16 +14,16 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collector;
-
 @Mixin(value = ClassInstanceMultiMap.class)
-public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T> {
+public abstract class ClassInstanceMultiMapMixin<
+    T
+> extends AbstractCollection<T> {
 
+    // Per-instance lock instead of static lock. The old static lock serialized every
+    // entity add/remove across ALL sections in the entire world on one object.
+    // Per-instance means sections in different chunks never contend with each other.
     @Unique
-    private static final Object async$lock = new Object();
+    private final Object async$lock = new Object();
 
     @Shadow
     private final Map<Class<?>, List<T>> byClass = new ConcurrentHashMap<>();
@@ -27,8 +31,16 @@ public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T
     @Shadow
     private final List<T> allInstances = new CopyOnWriteArrayList<>();
 
-    @ModifyArg(method = {"lambda$find$0", "m_13537_"}, at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"))
-    private Collector<T, ?, List<T>> overwriteCollectToList(Collector<T, ?, List<T>> collector) {
+    @ModifyArg(
+        method = { "lambda$find$0", "m_13537_" },
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"
+        )
+    )
+    private Collector<T, ?, List<T>> overwriteCollectToList(
+        Collector<T, ?, List<T>> collector
+    ) {
         return ConcurrentCollections.toList();
     }
 


### PR DESCRIPTION
In the interest of ease. I had Claude write up a summary of what was changed.


#### 1. ParallelProcessor Queue Rewrite (`ParallelProcessor.java`)

- **Replaced raw arrays with jctools queues** — Entity, despawn, and spawn pending collections replaced manual index-managed arrays (`pendingEntities[]`, `pendingDespawns[]`, `pendingCount`/`despawnCount`) with specialized queues:
  - `SpscLinkedQueue` for entity and despawn queues (single producer/single consumer — no CAS overhead)
  - `MpscUnboundedArrayQueue` for external task queue (multiple producers from pool workers, single consumer on main thread)
- **Introduced lightweight records** — `EntityTickEntry` and `SpawnEntry` replace parallel arrays of worlds/entities, improving readability with zero-copy pointer semantics.
- **Thread detection rewrite** — Replaced the `WeakReference<Thread>` + `ConcurrentHashMap` streaming lookup in `isServerExecutionThread()` with a `ThreadLocal<Boolean>` flag set via a custom `AsyncTickWorkerThread` subclass of `ForkJoinWorkerThread`. O(1) instead of O(n) per check.
- **Optimized `shouldTickSynchronously()`** — Reordered checks from cheapest to most expensive (config flag → instanceof → class set lookup → UUID blacklist → config string hash).
- **Backoff idle strategy in `postEntityTick()`** — Replaced flat `LockSupport.parkNanos(1_000L)` with spin → yield → progressive park (up to 100us), resetting on useful work.
- **Eliminated `Arrays.fill()` cleanup** — Local arrays are now GC-eligible immediately instead of requiring null-fills on persistent arrays.

#### 2. Double-Buffered Entity Spawning

- **Spawn work double-buffer** — `spawnCollect` and `spawnSubmit` ArrayLists are swapped by reference on each cycle. Zero drain, zero copy, zero allocation during the swap. The main thread fills one while a pool thread processes the other.
- **Fixed spawn task drop** — Previous code silently discarded pending spawn work if the last cycle was still running. Now `quietlyJoin()`s the previous task to guarantee no spawn work is lost.

#### 3. Per-Instance Locking in ClassInstanceMultiMap (`ClassInstanceMultiMapMixin.java`, Fabric + NeoForge)

- **`static` lock → instance lock** — The old `static final Object async$lock` serialized every entity add/remove across ALL entity sections in the entire world. Changed to a per-instance `final Object async$lock` so sections in different chunks never contend with each other.

#### 4. Removed Redundant Section-Level Lock (`EntitySectionMixin.java`)

- **Removed `async$storageLock` and `add()`/`remove()` overwrites** — `ClassInstanceMultiMap` already has a per-instance lock via the mixin above. The duplicate lock at the `EntitySection` level just doubled contention for zero safety gain.
- **Eliminated redundant `.toList().stream()` copy** in `getEntities()` — `CopyOnWriteArrayList.stream()` already iterates a snapshot, so the intermediate list copy was unnecessary.

#### 5. Double-Checked Locking in EntitySectionStorage (`EntitySectionStorageMixin.java`)

- Added proper double-checked locking in `getOrCreateSection()` — re-checks inside the synchronized block to prevent duplicate section creation from concurrent calls.

#### 6. Batch/Leaf System for Random Ticks (`ChunkMapMixin.java`)

- **Replaced per-chunk `CompletableFuture` with `RecursiveAction`** — `forEachBlockTickingChunk()` now collects all eligible chunks into an array, then submits a single `RandomTickBatch` RecursiveAction that fork-joins with a grain size of 16. Eliminates per-chunk Future allocation and MPSC queue CAS overhead.

#### 7. Tree-Merge Spawn Data Collection (`ParallelSpawnHelper.java`, `NaturalSpawnerMixin.java`)

- **`RecursiveAction` → `RecursiveTask<SpawnResult>`** — Spawn data collection now uses a tree-merge pattern. Each leaf accumulates results locally into a `SpawnResult` (mob counts, charge entries, mob cap entries) with zero shared mutable state. Parent tasks merge child results up the fork-join tree.
- **Eliminated `ConcurrentLinkedQueue<SpawnEntry>`** — No more per-entity record allocation into a shared queue. Replaced with local `Object2IntOpenHashMap` and `ArrayList` accumulation per leaf.
- **Separated concerns** — `SpawnEntry` (one fat record) split into `ChargeEntry` and `MobCapEntry`, with mob counts accumulated directly into `Object2IntOpenHashMap`. Only non-null charges are recorded.

#### 8. PotentialCalculator Fix (`PotentialCalculatorMixin.java`)

- **`CopyOnWriteArrayList` → `ArrayList`** — Charges are built sequentially on the main thread, then only read during spawn. COWAL was O(n) per `addCharge` (full array copy each time) = O(n²) total. Plain ArrayList is O(1) amortized.

---

### Performance Impact Summary

| Area | Before | After |
|------|--------|-------|
| Thread detection | O(n) stream over WeakRefs | O(1) ThreadLocal |
| Entity queue | Manual array + index | SPSC queue (zero CAS) |
| External task queue | ConcurrentLinkedQueue | MPSC array queue (cache-friendly) |
| Entity section locking | Global static lock | Per-instance lock |
| Random tick dispatch | Per-chunk CompletableFuture | Single RecursiveAction batch |
| Spawn data collection | Shared ConcurrentLinkedQueue | Tree-merge (no shared state) |
| PotentialCalculator.addCharge | O(n) per call (COWAL copy) | O(1) amortized (ArrayList) |
| Spawn work buffering | Copy + clear | Double-buffer swap |
| Idle wait strategy | Flat 1us park | Spin → yield → progressive park |

