### PR TITLE
An assortment of changes

### DIFF
--- a/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
+++ b/common/src/main/java/com/axalotl/async/common/ParallelProcessor.java
@@ -2,6 +2,11 @@ package com.axalotl.async.common;
 
 import com.axalotl.async.common.config.AsyncConfig;
 import com.axalotl.async.common.parallelised.utils.VanishCompat;
+import io.netty.util.internal.shaded.org.jctools.queues.MpscUnboundedArrayQueue;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.server.MinecraftServer;
@@ -20,14 +25,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.ref.WeakReference;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.LockSupport;
-
 public class ParallelProcessor {
-    public static final Logger LOGGER = LogManager.getLogger(ParallelProcessor.class);
+
+    public static final Logger LOGGER = LogManager.getLogger(
+        ParallelProcessor.class
+    );
 
     @Getter
     @Setter
@@ -37,71 +39,101 @@ public class ParallelProcessor {
     public static final AtomicInteger currentEntities = new AtomicInteger();
     private static final Object ENTITY_ADD_LOCK = new Object();
     private static final AtomicInteger threadPoolID = new AtomicInteger();
-    private static final Set<UUID> blacklistedEntity = ConcurrentHashMap.newKeySet();
-    private static final Map<String, Set<WeakReference<Thread>>> mcThreadTracker = new ConcurrentHashMap<>();
+    private static final Set<UUID> blacklistedEntity =
+        ConcurrentHashMap.newKeySet();
     private static volatile boolean isShuttingDown = false;
 
-    private static int despawnCount = 0;
+    private static final ThreadLocal<Boolean> IS_ASYNC_TICK_THREAD =
+        ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     private static int pendingCount = 0;
+    private static int despawnCount = 0;
     private static final int ENTITY_GRAIN = 64;
     private static final int DESPAWN_GRAIN = 128;
     private static final int INITIAL_CAPACITY = 16384;
+    private static final long POST_TICK_TIMEOUT_SECS = 10;
     private static volatile ForkJoinTask<?> currentSpawnTask;
     private static Entity[] pendingDespawns = new Entity[4096];
     private static Entity[] pendingEntities = new Entity[INITIAL_CAPACITY];
-    private static final ArrayList<Runnable> pendingSpawnWork = new ArrayList<>();
-    private static ServerLevel[] pendingWorlds = new ServerLevel[INITIAL_CAPACITY];
-    private static final ConcurrentLinkedQueue<CompletableFuture<?>> externalTaskQueue = new ConcurrentLinkedQueue<>();
+    private static ServerLevel[] pendingWorlds =
+        new ServerLevel[INITIAL_CAPACITY];
+    private static ArrayList<SpawnEntry> spawnCollect = new ArrayList<>();
+    private static ArrayList<SpawnEntry> spawnSubmit = new ArrayList<>();
+    private static final Queue<CompletableFuture<?>> externalTaskQueue =
+        new MpscUnboundedArrayQueue<>(256);
+
+    record SpawnEntry(
+        ServerLevel level,
+        LevelChunk chunk,
+        NaturalSpawner.SpawnState spawnState,
+        List<MobCategory> categories
+    ) {}
 
     public static final Set<Class<?>> BLOCKED_ENTITIES = Set.of(
-            FallingBlockEntity.class,
-            Shulker.class,
-            AbstractBoat.class
+        FallingBlockEntity.class,
+        Shulker.class,
+        AbstractBoat.class
     );
+
+    private static final class AsyncTickWorkerThread
+        extends ForkJoinWorkerThread
+    {
+
+        AsyncTickWorkerThread(ForkJoinPool pool) {
+            super(pool);
+        }
+
+        @Override
+        protected void onStart() {
+            super.onStart();
+            IS_ASYNC_TICK_THREAD.set(Boolean.TRUE);
+        }
+    }
 
     public static void setupThreadPool(int parallelism, Class<?> asyncClass) {
         isShuttingDown = false;
 
-        ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory = pool -> {
-            ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-            worker.setName("Async-Tick-Pool-Thread-" + threadPoolID.getAndIncrement());
-            registerThread("Async-Tick", worker);
-            worker.setDaemon(true);
-            worker.setPriority(Thread.NORM_PRIORITY);
-            worker.setContextClassLoader(asyncClass.getClassLoader());
-            return worker;
-        };
+        tickPool = new ForkJoinPool(
+            parallelism,
+            pool -> {
+                AsyncTickWorkerThread worker = new AsyncTickWorkerThread(pool);
+                worker.setName(
+                    "Async-Tick-Pool-Thread-" + threadPoolID.getAndIncrement()
+                );
+                worker.setDaemon(true);
+                worker.setPriority(Thread.NORM_PRIORITY);
+                worker.setContextClassLoader(asyncClass.getClassLoader());
+                return worker;
+            },
+            (t, e) ->
+                LOGGER.error(
+                    "Uncaught exception in thread {}: {}",
+                    t.getName(),
+                    e
+                ),
+            true
+        );
 
-        tickPool = new ForkJoinPool(parallelism, threadFactory, (t, e) ->
-                LOGGER.error("Uncaught exception in thread {}: {}", t.getName(), e), true);
         LOGGER.info("Initialized Pool with {} threads", parallelism);
         VanishCompat.apply();
     }
 
     public static void registerThread(String poolName, Thread thread) {
-        mcThreadTracker
-                .computeIfAbsent(poolName, key -> ConcurrentHashMap.newKeySet())
-                .add(new WeakReference<>(thread));
-    }
-
-    private static boolean isThreadInPool(Thread thread) {
-        return mcThreadTracker.getOrDefault("Async-Tick", Set.of()).stream()
-                .map(WeakReference::get)
-                .anyMatch(thread::equals);
+        // No-op: threads from our own pool are marked in AsyncTickWorkerThread.onStart().
     }
 
     public static boolean isServerExecutionThread() {
-        return isThreadInPool(Thread.currentThread());
+        return IS_ASYNC_TICK_THREAD.get();
     }
 
     public static void callEntityTick(ServerLevel world, Entity entity) {
-        if (isShuttingDown) {
-            world.tickNonPassenger(entity);
+        if (isShuttingDown || tickPool == null || tickPool.isShutdown()) {
+            safeTickSync(world, entity);
             return;
         }
 
         if (shouldTickSynchronously(entity)) {
-            world.tickNonPassenger(entity);
+            safeTickSync(world, entity);
             return;
         }
 
@@ -116,25 +148,31 @@ public class ParallelProcessor {
         pendingCount = idx + 1;
     }
 
+    private static void safeTickSync(ServerLevel world, Entity entity) {
+        try {
+            world.tickNonPassenger(entity);
+        } catch (Throwable t) {
+            LOGGER.error(
+                "Error during synchronous entity tick. Type: {}, UUID: {}",
+                entity.getType(),
+                entity.getUUID(),
+                t
+            );
+        }
+    }
+
     public static boolean shouldTickSynchronously(Entity entity) {
-        if (entity.level().isClientSide()) {
-            return true;
-        }
-
-        UUID entityId = entity.getUUID();
-        boolean requiresSyncTick = AsyncConfig.disabled ||
-                entity instanceof Projectile ||
-                entity instanceof AbstractMinecart ||
-                entity instanceof ServerPlayer ||
-                BLOCKED_ENTITIES.contains(entity.getClass()) ||
-                blacklistedEntity.contains(entityId) ||
-                AsyncConfig.isEntitySynchronized(EntityType.getKey(entity.getType()));
-
-        if (requiresSyncTick) {
-            return true;
-        }
-
-        return entity.portalProcess != null;
+        if (AsyncConfig.disabled) return true;
+        if (entity instanceof ServerPlayer) return true;
+        if (entity instanceof Projectile) return true;
+        if (entity instanceof AbstractMinecart) return true;
+        if (entity.level().isClientSide()) return true;
+        if (BLOCKED_ENTITIES.contains(entity.getClass())) return true;
+        if (entity.portalProcess != null) return true;
+        if (blacklistedEntity.contains(entity.getUUID())) return true;
+        return AsyncConfig.isEntitySynchronized(
+            EntityType.getKey(entity.getType())
+        );
     }
 
     public static Object getEntityAddLock() {
@@ -142,14 +180,23 @@ public class ParallelProcessor {
     }
 
     static final class EntityTickBatch extends RecursiveAction {
+
         private final ServerLevel[] worlds;
         private final Entity[] entities;
+        private final boolean[] completed;
         private final int from;
         private final int to;
 
-        EntityTickBatch(ServerLevel[] worlds, Entity[] entities, int from, int to) {
+        EntityTickBatch(
+            ServerLevel[] worlds,
+            Entity[] entities,
+            boolean[] completed,
+            int from,
+            int to
+        ) {
             this.worlds = worlds;
             this.entities = entities;
+            this.completed = completed;
             this.from = from;
             this.to = to;
         }
@@ -159,19 +206,31 @@ public class ParallelProcessor {
             int size = to - from;
             if (size <= ENTITY_GRAIN) {
                 for (int i = from; i < to; i++) {
-                    worlds[i].tickNonPassenger(entities[i]);
+                    try {
+                        worlds[i].tickNonPassenger(entities[i]);
+                        completed[i] = true;
+                    } catch (Throwable t) {
+                        LOGGER.error(
+                            "Async entity tick error, blacklisting entity. Type: {}, UUID: {}",
+                            entities[i].getType(),
+                            entities[i].getUUID(),
+                            t
+                        );
+                        blacklistedEntity.add(entities[i].getUUID());
+                    }
                 }
             } else {
                 int mid = (from + to) >>> 1;
                 invokeAll(
-                        new EntityTickBatch(worlds, entities, from, mid),
-                        new EntityTickBatch(worlds, entities, mid, to)
+                    new EntityTickBatch(worlds, entities, completed, from, mid),
+                    new EntityTickBatch(worlds, entities, completed, mid, to)
                 );
             }
         }
     }
 
     static final class DespawnBatch extends RecursiveAction {
+
         private final Entity[] entities;
         private final int from;
         private final int to;
@@ -187,71 +246,106 @@ public class ParallelProcessor {
             int size = to - from;
             if (size <= DESPAWN_GRAIN) {
                 for (int i = from; i < to; i++) {
-                    entities[i].checkDespawn();
+                    try {
+                        entities[i].checkDespawn();
+                    } catch (Throwable t) {
+                        LOGGER.error(
+                            "Async despawn error for entity. Type: {}, UUID: {}",
+                            entities[i].getType(),
+                            entities[i].getUUID(),
+                            t
+                        );
+                    }
                 }
             } else {
                 int mid = (from + to) >>> 1;
                 invokeAll(
-                        new DespawnBatch(entities, from, mid),
-                        new DespawnBatch(entities, mid, to)
+                    new DespawnBatch(entities, from, mid),
+                    new DespawnBatch(entities, mid, to)
                 );
             }
         }
     }
 
     public static void asyncSpawnForChunk(
-            ServerLevel level,
-            LevelChunk chunk,
-            NaturalSpawner.SpawnState spawnState,
-            List<MobCategory> categories
+        ServerLevel level,
+        LevelChunk chunk,
+        NaturalSpawner.SpawnState spawnState,
+        List<MobCategory> categories
     ) {
-        if (!chunk.loaded) {
-            return;
-        }
+        if (!chunk.loaded) return;
 
-        if (isShuttingDown || AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) {
+        if (
+            isShuttingDown ||
+            tickPool == null ||
+            tickPool.isShutdown() ||
+            AsyncConfig.disabled ||
+            !AsyncConfig.enableAsyncSpawn
+        ) {
             NaturalSpawner.spawnForChunk(level, chunk, spawnState, categories);
             return;
         }
 
-        if (categories.isEmpty()) {
-            return;
-        }
+        if (categories.isEmpty()) return;
 
-        List<MobCategory> categoriesCopy = List.copyOf(categories);
-        pendingSpawnWork.add(() -> NaturalSpawner.spawnForChunk(level, chunk, spawnState, categoriesCopy));
+        spawnCollect.add(
+            new SpawnEntry(level, chunk, spawnState, List.copyOf(categories))
+        );
     }
 
     private static void submitSpawnCycle() {
-        if (pendingSpawnWork.isEmpty()) {
-            return;
-        }
+        if (spawnCollect.isEmpty()) return;
 
         ForkJoinTask<?> prev = currentSpawnTask;
         if (prev != null && !prev.isDone()) {
-            pendingSpawnWork.clear();
-            return;
+            prev.quietlyJoin();
         }
 
-        Runnable[] work = pendingSpawnWork.toArray(new Runnable[0]);
-        pendingSpawnWork.clear();
+        ArrayList<SpawnEntry> ready = spawnCollect;
+        spawnCollect = spawnSubmit;
+        spawnCollect.clear();
+        spawnSubmit = ready;
 
         currentSpawnTask = tickPool.submit(() -> {
-            for (Runnable task : work) {
-                task.run();
+            for (int i = 0, n = ready.size(); i < n; i++) {
+                SpawnEntry s = ready.get(i);
+                try {
+                    NaturalSpawner.spawnForChunk(
+                        s.level(),
+                        s.chunk(),
+                        s.spawnState(),
+                        s.categories()
+                    );
+                } catch (Throwable t) {
+                    LOGGER.error(
+                        "Error during async spawn for chunk at [{}, {}]",
+                        s.chunk().getPos().x,
+                        s.chunk().getPos().z,
+                        t
+                    );
+                }
             }
         });
     }
 
     public static void asyncDespawn(Entity entity) {
-        if (isShuttingDown || AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) {
+        if (
+            isShuttingDown ||
+            tickPool == null ||
+            tickPool.isShutdown() ||
+            AsyncConfig.disabled ||
+            !AsyncConfig.enableAsyncSpawn
+        ) {
             entity.checkDespawn();
             return;
         }
 
         int idx = despawnCount;
         if (idx >= pendingDespawns.length) {
-            pendingDespawns = Arrays.copyOf(pendingDespawns, pendingDespawns.length << 1);
+            pendingDespawns = Arrays.copyOf(
+                pendingDespawns,
+                pendingDespawns.length << 1
+            );
         }
         pendingDespawns[idx] = entity;
         despawnCount = idx + 1;
@@ -267,17 +361,24 @@ public class ParallelProcessor {
         submitSpawnCycle();
 
         ForkJoinTask<?> entityTask = null;
-        ForkJoinTask<?> despawnTask = null;
-
         int entityCount = pendingCount;
+        boolean[] entityCompleted = null;
         pendingCount = 0;
 
         if (entityCount > 0) {
+            entityCompleted = new boolean[entityCount];
             currentEntities.set(entityCount);
-            entityTask = new EntityTickBatch(pendingWorlds, pendingEntities, 0, entityCount);
+            entityTask = new EntityTickBatch(
+                pendingWorlds,
+                pendingEntities,
+                entityCompleted,
+                0,
+                entityCount
+            );
             tickPool.execute(entityTask);
         }
 
+        ForkJoinTask<?> despawnTask = null;
         int dCount = despawnCount;
         despawnCount = 0;
 
@@ -287,28 +388,73 @@ public class ParallelProcessor {
         }
 
         CompletableFuture<Void> externalFuture = null;
-        List<CompletableFuture<?>> externalTasks = null;
-        CompletableFuture<?> f;
-        while ((f = externalTaskQueue.poll()) != null) {
-            if (externalTasks == null) {
-                externalTasks = new ArrayList<>();
+        {
+            CompletableFuture<?> f;
+            ArrayList<CompletableFuture<?>> externalTasks = null;
+            while ((f = externalTaskQueue.poll()) != null) {
+                if (externalTasks == null) externalTasks = new ArrayList<>();
+                externalTasks.add(f);
             }
-            externalTasks.add(f);
+            if (externalTasks != null) {
+                externalFuture = CompletableFuture.allOf(
+                    externalTasks.toArray(CompletableFuture[]::new)
+                );
+            }
         }
-        if (externalTasks != null) {
-            externalFuture = CompletableFuture.allOf(externalTasks.toArray(new CompletableFuture[0]));
-        }
+
+        // Spawn task is intentionally NOT waited on here - it pipelines across ticks.
+        // submitSpawnCycle() joins the previous spawn task if still running.
+        long deadlineNanos =
+            System.nanoTime() +
+            TimeUnit.SECONDS.toNanos(POST_TICK_TIMEOUT_SECS);
 
         while (true) {
-            boolean allDone = entityTask == null || entityTask.isDone();
-            if (despawnTask != null && !despawnTask.isDone()) {
-                allDone = false;
-            }
-            if (externalFuture != null && !externalFuture.isDone()) {
-                allDone = false;
-            }
+            boolean allDone =
+                (entityTask == null || entityTask.isDone()) &&
+                (despawnTask == null || despawnTask.isDone()) &&
+                (externalFuture == null || externalFuture.isDone());
 
             if (allDone) break;
+
+            if (System.nanoTime() > deadlineNanos) {
+                LOGGER.error(
+                    "postEntityTick timed out after {}s waiting for async tasks. " +
+                        "Entity done: {}, Despawn done: {}, External done: {}. " +
+                        "Falling back to synchronous processing for incomplete work.",
+                    POST_TICK_TIMEOUT_SECS,
+                    entityTask == null || entityTask.isDone(),
+                    despawnTask == null || despawnTask.isDone(),
+                    externalFuture == null || externalFuture.isDone()
+                );
+
+                if (
+                    entityTask != null && !entityTask.isDone()
+                ) entityTask.cancel(true);
+                if (
+                    despawnTask != null && !despawnTask.isDone()
+                ) despawnTask.cancel(true);
+                if (
+                    externalFuture != null && !externalFuture.isDone()
+                ) externalFuture.cancel(true);
+
+                if (entityCompleted != null) {
+                    int rescued = 0;
+                    for (int i = 0; i < entityCount; i++) {
+                        if (!entityCompleted[i]) {
+                            safeTickSync(pendingWorlds[i], pendingEntities[i]);
+                            rescued++;
+                        }
+                    }
+                    if (rescued > 0) {
+                        LOGGER.warn(
+                            "Synchronously rescued {} entities from timed-out async batch",
+                            rescued
+                        );
+                    }
+                }
+
+                break;
+            }
 
             boolean didWork = false;
             for (ServerLevel world : server.getAllLevels()) {
@@ -323,7 +469,10 @@ public class ParallelProcessor {
         if (entityTask != null) {
             entityTask.quietlyJoin();
             if (entityTask.isCompletedAbnormally()) {
-                LOGGER.error("Entity tick batch error", entityTask.getException());
+                LOGGER.error(
+                    "Entity tick batch error",
+                    entityTask.getException()
+                );
             }
             Arrays.fill(pendingWorlds, 0, entityCount, null);
             Arrays.fill(pendingEntities, 0, entityCount, null);
@@ -337,6 +486,7 @@ public class ParallelProcessor {
             }
             Arrays.fill(pendingDespawns, 0, dCount, null);
         }
+
         for (ServerLevel world : server.getAllLevels()) {
             world.getChunkSource().pollTask();
         }
@@ -350,13 +500,15 @@ public class ParallelProcessor {
             spawn.quietlyJoin();
         }
 
-        List<CompletableFuture<?>> remaining = new ArrayList<>();
+        ArrayList<CompletableFuture<?>> remaining = new ArrayList<>();
         CompletableFuture<?> f;
         while ((f = externalTaskQueue.poll()) != null) {
             remaining.add(f);
         }
         if (!remaining.isEmpty()) {
-            CompletableFuture.allOf(remaining.toArray(new CompletableFuture[0])).join();
+            CompletableFuture.allOf(
+                remaining.toArray(CompletableFuture[]::new)
+            ).join();
         }
 
         if (tickPool != null) {
@@ -370,7 +522,8 @@ public class ParallelProcessor {
 
         AsyncConfig.clearCaches();
         blacklistedEntity.clear();
-        pendingSpawnWork.clear();
+        spawnCollect.clear();
+        spawnSubmit.clear();
         pendingCount = 0;
         despawnCount = 0;
     }

--- a/common/src/main/java/com/axalotl/async/common/RandomTickBatch.java
+++ b/common/src/main/java/com/axalotl/async/common/RandomTickBatch.java
@@ -1,0 +1,50 @@
+package com.axalotl.async.common;
+
+import java.util.concurrent.RecursiveAction;
+import java.util.function.Consumer;
+import net.minecraft.world.level.chunk.LevelChunk;
+
+public final class RandomTickBatch extends RecursiveAction {
+
+    private static final int RANDOM_TICK_GRAIN = 16;
+
+    private final LevelChunk[] chunks;
+    private final int from;
+    private final int to;
+    private final Consumer<LevelChunk> action;
+
+    public RandomTickBatch(
+        LevelChunk[] chunks,
+        int from,
+        int to,
+        Consumer<LevelChunk> action
+    ) {
+        this.chunks = chunks;
+        this.from = from;
+        this.to = to;
+        this.action = action;
+    }
+
+    @Override
+    protected void compute() {
+        int size = to - from;
+        if (size <= RANDOM_TICK_GRAIN) {
+            for (int i = from; i < to; i++) {
+                try {
+                    action.accept(chunks[i]);
+                } catch (Throwable e) {
+                    ParallelProcessor.LOGGER.error(
+                        "Error in async random tick",
+                        e
+                    );
+                }
+            }
+        } else {
+            int mid = (from + to) >>> 1;
+            invokeAll(
+                new RandomTickBatch(chunks, from, mid, action),
+                new RandomTickBatch(chunks, mid, to, action)
+            );
+        }
+    }
+}

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
@@ -26,8 +26,7 @@ public class EntitySectionMixin<T extends EntityAccess> {
     private Visibility chunkStatus;
 
     @Unique
-    private final AtomicReference<Visibility> async$atomicStatus =
-        new AtomicReference<>(Visibility.HIDDEN);
+    private final AtomicReference<Visibility> async$atomicStatus = new AtomicReference<>(Visibility.HIDDEN);
 
     @Unique
     private final Object async$storageLock = new Object();

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionMixin.java
@@ -2,6 +2,9 @@ package com.axalotl.async.common.mixin.entity.movement;
 
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import net.minecraft.util.ClassInstanceMultiMap;
 import net.minecraft.world.level.entity.EntityAccess;
 import net.minecraft.world.level.entity.EntitySection;
@@ -10,10 +13,6 @@ import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 
 @Mixin(EntitySection.class)
 public class EntitySectionMixin<T extends EntityAccess> {
@@ -27,13 +26,18 @@ public class EntitySectionMixin<T extends EntityAccess> {
     private Visibility chunkStatus;
 
     @Unique
-    private final AtomicReference<Visibility> async$atomicStatus = new AtomicReference<>(Visibility.HIDDEN);
+    private final AtomicReference<Visibility> async$atomicStatus =
+        new AtomicReference<>(Visibility.HIDDEN);
 
     @Unique
     private final Object async$storageLock = new Object();
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void async$init(Class<?> clazz, Visibility status, CallbackInfo ci) {
+    private void async$init(
+        Class<?> clazz,
+        Visibility status,
+        CallbackInfo ci
+    ) {
         async$atomicStatus.set(status != null ? status : Visibility.HIDDEN);
     }
 
@@ -82,9 +86,6 @@ public class EntitySectionMixin<T extends EntityAccess> {
 
     @WrapMethod(method = "getEntities()Ljava/util/stream/Stream;")
     private Stream<T> getEntities(Operation<Stream<T>> original) {
-        return storage.stream()
-                .filter(Objects::nonNull)
-                .toList()
-                .stream();
+        return storage.stream().filter(Objects::nonNull);
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionStorageMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionStorageMixin.java
@@ -37,10 +37,7 @@ public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
     private final Object async$Lock = new Object();
 
     @WrapMethod(method = "getOrCreateSection")
-    private EntitySection<T> getOrCreateSection(
-        long pos,
-        Operation<EntitySection<T>> original
-    ) {
+    private EntitySection<T> getOrCreateSection(long pos, Operation<EntitySection<T>> original) {
         EntitySection<T> existing = this.sections.get(pos);
         if (existing != null) return existing;
         synchronized (async$Lock) {
@@ -57,10 +54,7 @@ public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
     }
 
     @WrapMethod(method = "getExistingSectionsInChunk")
-    private Stream<EntitySection<T>> getExistingSections(
-        long pos,
-        Operation<Stream<EntitySection<T>>> original
-    ) {
+    private Stream<EntitySection<T>> getExistingSections(long pos, Operation<Stream<EntitySection<T>>> original) {
         return this.getExistingSectionPositionsInChunk(pos)
             .mapToObj(this.sections::get)
             .filter(Objects::nonNull)

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionStorageMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/movement/EntitySectionStorageMixin.java
@@ -6,6 +6,9 @@ import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
+import java.util.Objects;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import net.minecraft.world.level.entity.EntityAccess;
 import net.minecraft.world.level.entity.EntitySection;
 import net.minecraft.world.level.entity.EntitySectionStorage;
@@ -13,10 +16,6 @@ import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Objects;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 @Mixin(value = EntitySectionStorage.class)
 public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
@@ -34,15 +33,19 @@ public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
     @Shadow
     public abstract LongStream getExistingSectionPositionsInChunk(long pos);
 
-
     @Unique
     private final Object async$Lock = new Object();
 
     @WrapMethod(method = "getOrCreateSection")
-    private EntitySection<T> getOrCreateSection(long pos, Operation<EntitySection<T>> original) {
+    private EntitySection<T> getOrCreateSection(
+        long pos,
+        Operation<EntitySection<T>> original
+    ) {
         EntitySection<T> existing = this.sections.get(pos);
         if (existing != null) return existing;
         synchronized (async$Lock) {
+            existing = this.sections.get(pos);
+            if (existing != null) return existing;
             return original.call(pos);
         }
     }
@@ -54,11 +57,14 @@ public abstract class EntitySectionStorageMixin<T extends EntityAccess> {
     }
 
     @WrapMethod(method = "getExistingSectionsInChunk")
-    private Stream<EntitySection<T>> getExistingSections(long pos, Operation<Stream<EntitySection<T>>> original) {
+    private Stream<EntitySection<T>> getExistingSections(
+        long pos,
+        Operation<Stream<EntitySection<T>>> original
+    ) {
         return this.getExistingSectionPositionsInChunk(pos)
-                .mapToObj(this.sections::get)
-                .filter(Objects::nonNull)
-                .toList()
-                .stream();
+            .mapToObj(this.sections::get)
+            .filter(Objects::nonNull)
+            .toList()
+            .stream();
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/NaturalSpawnerMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/NaturalSpawnerMixin.java
@@ -2,9 +2,13 @@ package com.axalotl.async.common.mixin.entity.spawn;
 
 import com.axalotl.async.common.ParallelProcessor;
 import com.axalotl.async.common.config.AsyncConfig;
+import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.ChargeEntry;
+import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.MobCapEntry;
 import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.SpawnDataCollector;
-import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.SpawnEntry;
+import com.axalotl.async.common.parallelised.spawn.ParallelSpawnHelper.SpawnResult;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.LocalMobCapCalculator;
@@ -16,20 +20,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 @Mixin(value = NaturalSpawner.class, priority = 900)
 public abstract class NaturalSpawnerMixin {
 
     @Inject(method = "createState", at = @At("HEAD"), cancellable = true)
     private static void async$createState(
-            int spawnableChunkCount,
-            Iterable<Entity> entities,
-            NaturalSpawner.ChunkGetter chunkGetter,
-            LocalMobCapCalculator localMobCapCalculator,
-            CallbackInfoReturnable<NaturalSpawner.SpawnState> cir
+        int spawnableChunkCount,
+        Iterable<Entity> entities,
+        NaturalSpawner.ChunkGetter chunkGetter,
+        LocalMobCapCalculator localMobCapCalculator,
+        CallbackInfoReturnable<NaturalSpawner.SpawnState> cir
     ) {
         if (AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) {
             return;
@@ -37,15 +37,22 @@ public abstract class NaturalSpawnerMixin {
         if (ParallelProcessor.tickPool == null) {
             return;
         }
-        cir.setReturnValue(async$createStateParallel(spawnableChunkCount, entities, chunkGetter, localMobCapCalculator));
+        cir.setReturnValue(
+            async$createStateParallel(
+                spawnableChunkCount,
+                entities,
+                chunkGetter,
+                localMobCapCalculator
+            )
+        );
     }
 
     @Unique
     private static NaturalSpawner.SpawnState async$createStateParallel(
-            int spawnableChunkCount,
-            Iterable<Entity> entities,
-            NaturalSpawner.ChunkGetter chunkGetter,
-            LocalMobCapCalculator localMobCapCalculator
+        int spawnableChunkCount,
+        Iterable<Entity> entities,
+        NaturalSpawner.ChunkGetter chunkGetter,
+        LocalMobCapCalculator localMobCapCalculator
     ) {
         List<Entity> entityList;
         if (entities instanceof List<Entity> list) {
@@ -57,31 +64,40 @@ public abstract class NaturalSpawnerMixin {
 
         if (entityList.isEmpty()) {
             return new NaturalSpawner.SpawnState(
-                    spawnableChunkCount,
-                    new Object2IntOpenHashMap<>(),
-                    new PotentialCalculator(),
-                    localMobCapCalculator
+                spawnableChunkCount,
+                new Object2IntOpenHashMap<>(),
+                new PotentialCalculator(),
+                localMobCapCalculator
             );
         }
 
-        ConcurrentLinkedQueue<SpawnEntry> results = new ConcurrentLinkedQueue<>();
         Entity[] entityArray = entityList.toArray(new Entity[0]);
 
-        SpawnDataCollector task = new SpawnDataCollector(entityArray, chunkGetter, results, 0, entityArray.length);
-        ParallelProcessor.tickPool.invoke(task);
+        SpawnResult result = ParallelProcessor.tickPool.invoke(
+            new SpawnDataCollector(
+                entityArray,
+                chunkGetter,
+                0,
+                entityArray.length
+            )
+        );
 
-        // Sequential merge
         PotentialCalculator potentialCalculator = new PotentialCalculator();
-        Object2IntOpenHashMap<MobCategory> mobCounts = new Object2IntOpenHashMap<>();
-
-        for (SpawnEntry data : results) {
-            potentialCalculator.addCharge(data.pos(), data.charge());
-            if (data.isMob()) {
-                localMobCapCalculator.addMob(data.chunkPos(), data.category());
-            }
-            mobCounts.addTo(data.category(), 1);
+        for (int i = 0, n = result.charges.size(); i < n; i++) {
+            ChargeEntry c = result.charges.get(i);
+            potentialCalculator.addCharge(c.pos(), c.charge());
         }
 
-        return new NaturalSpawner.SpawnState(spawnableChunkCount, mobCounts, potentialCalculator, localMobCapCalculator);
+        for (int i = 0, n = result.mobCapEntries.size(); i < n; i++) {
+            MobCapEntry m = result.mobCapEntries.get(i);
+            localMobCapCalculator.addMob(m.chunkPos(), m.category());
+        }
+
+        return new NaturalSpawner.SpawnState(
+            spawnableChunkCount,
+            result.mobCounts,
+            potentialCalculator,
+            localMobCapCalculator
+        );
     }
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/PotentialCalculatorMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/entity/spawn/PotentialCalculatorMixin.java
@@ -1,15 +1,15 @@
 package com.axalotl.async.common.mixin.entity.spawn;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.world.level.PotentialCalculator;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(PotentialCalculator.class)
 public class PotentialCalculatorMixin {
 
     @Shadow
-    private final List<PotentialCalculator.PointCharge> charges = new CopyOnWriteArrayList<>();
+    private final List<PotentialCalculator.PointCharge> charges =
+        new ArrayList<>();
 }

--- a/common/src/main/java/com/axalotl/async/common/mixin/server/ChunkMapMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/server/ChunkMapMixin.java
@@ -1,6 +1,7 @@
 package com.axalotl.async.common.mixin.server;
 
 import com.axalotl.async.common.ParallelProcessor;
+import com.axalotl.async.common.RandomTickBatch;
 import com.axalotl.async.common.config.AsyncConfig;
 import com.axalotl.async.common.parallelised.fastutil.ConcurrentLongLinkedOpenHashSet;
 import com.axalotl.async.common.parallelised.fastutil.Int2ObjectConcurrentHashMap;
@@ -11,6 +12,12 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ChunkGenerationTask;
 import net.minecraft.server.level.ChunkHolder;
@@ -32,15 +39,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Consumer;
-
 @Mixin(value = ChunkMap.class, priority = 1500)
-public abstract class ChunkMapMixin extends SimpleRegionStorage implements ChunkHolder.PlayerProvider {
+public abstract class ChunkMapMixin
+    extends SimpleRegionStorage
+    implements ChunkHolder.PlayerProvider
+{
 
     @Shadow
     @Final
@@ -68,7 +71,13 @@ public abstract class ChunkMapMixin extends SimpleRegionStorage implements Chunk
     @Final
     ServerLevel level;
 
-    public ChunkMapMixin(RegionStorageInfo p_326109_, Path p_321582_, DataFixer p_321815_, boolean p_321788_, DataFixTypes p_321522_) {
+    public ChunkMapMixin(
+        RegionStorageInfo p_326109_,
+        Path p_321582_,
+        DataFixer p_321815_,
+        boolean p_321788_,
+        DataFixTypes p_321522_
+    ) {
         super(p_326109_, p_321582_, p_321815_, p_321788_, p_321522_);
     }
 
@@ -80,27 +89,46 @@ public abstract class ChunkMapMixin extends SimpleRegionStorage implements Chunk
     }
 
     @WrapMethod(method = "addEntity")
-    private synchronized void addEntity(Entity entity, Operation<Void> original) {
+    private synchronized void addEntity(
+        Entity entity,
+        Operation<Void> original
+    ) {
         original.call(entity);
     }
 
     @WrapMethod(method = "removeEntity")
-    private synchronized void removeEntity(Entity entity, Operation<Void> original) {
+    private synchronized void removeEntity(
+        Entity entity,
+        Operation<Void> original
+    ) {
         original.call(entity);
     }
 
     @WrapMethod(method = "releaseGeneration")
-    private synchronized void releaseGeneration(GenerationChunkHolder chunk, Operation<Void> original) {
+    private synchronized void releaseGeneration(
+        GenerationChunkHolder chunk,
+        Operation<Void> original
+    ) {
         original.call(chunk);
     }
 
-    @Inject(method = "addEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;pauseInIde(Ljava/lang/Throwable;)Ljava/lang/Throwable;"), cancellable = true)
+    @Inject(
+        method = "addEntity",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/Util;pauseInIde(Ljava/lang/Throwable;)Ljava/lang/Throwable;"
+        ),
+        cancellable = true
+    )
     private void skipThrowLoadEntity(Entity entity, CallbackInfo ci) {
         ci.cancel();
     }
 
     @WrapMethod(method = "collectSpawningChunks")
-    private void async$optimizedCollectSpawningChunks(List<LevelChunk> result, Operation<Void> original) {
+    private void async$optimizedCollectSpawningChunks(
+        List<LevelChunk> result,
+        Operation<Void> original
+    ) {
         List<ServerPlayer> players = this.level.players();
         double[] playerX = new double[players.size()];
         double[] playerZ = new double[players.size()];
@@ -143,31 +171,39 @@ public abstract class ChunkMapMixin extends SimpleRegionStorage implements Chunk
     }
 
     @WrapMethod(method = "forEachBlockTickingChunk")
-    private void forEachBlockTickingChunk(Consumer<LevelChunk> action, Operation<Void> original) {
+    private void forEachBlockTickingChunk(
+        Consumer<LevelChunk> action,
+        Operation<Void> original
+    ) {
         if (!AsyncConfig.disabled && AsyncConfig.enableAsyncRandomTicks) {
-            // Snapshot chunk positions for thread-safe iteration
-            List<Long> keys = new ArrayList<>();
-            distanceManager.forEachEntityTickingChunk(keys::add);
-
-            for (long chunkPos : keys) {
-                ChunkHolder holder = visibleChunkMap.get(chunkPos);
+            ArrayList<LevelChunk> chunks = new ArrayList<>();
+            distanceManager.forEachEntityTickingChunk(pos -> {
+                ChunkHolder holder = visibleChunkMap.get(pos);
                 if (holder != null) {
                     LevelChunk chunk = holder.getTickingChunk();
                     if (chunk != null) {
-                        CompletableFuture<Void> future = CompletableFuture.runAsync(
-                                () -> {
-                                    if (chunk.getLevel() != null) {
-                                        action.accept(chunk);
-                                    }
-                                },
-                                ParallelProcessor.tickPool
-                        ).exceptionally(e -> {
-                            ParallelProcessor.LOGGER.error("Error in async random tick", e);
-                            return null;
-                        });
-                        ParallelProcessor.addTask(future);
+                        chunks.add(chunk);
                     }
                 }
+            });
+
+            if (!chunks.isEmpty()) {
+                LevelChunk[] arr = chunks.toArray(new LevelChunk[0]);
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                ParallelProcessor.tickPool.execute(() -> {
+                    try {
+                        new RandomTickBatch(
+                            arr,
+                            0,
+                            arr.length,
+                            action
+                        ).invoke();
+                        future.complete(null);
+                    } catch (Throwable e) {
+                        future.completeExceptionally(e);
+                    }
+                });
+                ParallelProcessor.addTask(future);
             }
         } else {
             original.call(action);

--- a/common/src/main/java/com/axalotl/async/common/parallelised/spawn/ParallelSpawnHelper.java
+++ b/common/src/main/java/com/axalotl/async/common/parallelised/spawn/ParallelSpawnHelper.java
@@ -1,5 +1,8 @@
 package com.axalotl.async.common.parallelised.spawn;
 
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.concurrent.RecursiveTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
@@ -8,11 +11,12 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.NaturalSpawner;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.RecursiveAction;
-
 /**
  * ForkJoinPool-native helpers for parallel createState() mob cap counting.
+ *
+ * Uses a tree-merge pattern: each leaf task accumulates results locally
+ * (no shared mutable state, no CAS), then parent tasks merge child results
+ * up the fork-join tree. The final merged result is returned to the caller.
  */
 public final class ParallelSpawnHelper {
 
@@ -20,47 +24,87 @@ public final class ParallelSpawnHelper {
 
     private static final int SPAWN_GRAIN = 256;
 
-    public record SpawnEntry(BlockPos pos, MobCategory category, double charge, boolean isMob, ChunkPos chunkPos) {}
+    public static final class SpawnResult {
 
-    /**
-     * RecursiveAction that splits entity array for work-stealing.
-     * Each leaf processes entities, calls chunkGetter.query() (O(1) via fullChunks map),
-     * and adds results to lock-free ConcurrentLinkedQueue.
-     */
-    public static final class SpawnDataCollector extends RecursiveAction {
+        public final Object2IntOpenHashMap<MobCategory> mobCounts =
+            new Object2IntOpenHashMap<>();
+        public final ArrayList<ChargeEntry> charges = new ArrayList<>();
+        public final ArrayList<MobCapEntry> mobCapEntries = new ArrayList<>();
+
+        public void merge(SpawnResult other) {
+            for (var entry : other.mobCounts.object2IntEntrySet()) {
+                mobCounts.addTo(entry.getKey(), entry.getIntValue());
+            }
+            charges.addAll(other.charges);
+            mobCapEntries.addAll(other.mobCapEntries);
+        }
+    }
+
+    public record ChargeEntry(BlockPos pos, double charge) {}
+
+    public record MobCapEntry(ChunkPos chunkPos, MobCategory category) {}
+
+    public static final class SpawnDataCollector
+        extends RecursiveTask<SpawnResult>
+    {
+
         private final Entity[] entities;
         private final NaturalSpawner.ChunkGetter chunkGetter;
-        private final ConcurrentLinkedQueue<SpawnEntry> results;
         private final int from;
         private final int to;
 
-        public SpawnDataCollector(Entity[] entities, NaturalSpawner.ChunkGetter chunkGetter,
-                                  ConcurrentLinkedQueue<SpawnEntry> results, int from, int to) {
+        public SpawnDataCollector(
+            Entity[] entities,
+            NaturalSpawner.ChunkGetter chunkGetter,
+            int from,
+            int to
+        ) {
             this.entities = entities;
             this.chunkGetter = chunkGetter;
-            this.results = results;
             this.from = from;
             this.to = to;
         }
 
         @Override
-        protected void compute() {
+        protected SpawnResult compute() {
             int size = to - from;
             if (size <= SPAWN_GRAIN) {
-                for (int i = from; i < to; i++) {
-                    processEntity(entities[i]);
-                }
-            } else {
-                int mid = (from + to) >>> 1;
-                invokeAll(
-                        new SpawnDataCollector(entities, chunkGetter, results, from, mid),
-                        new SpawnDataCollector(entities, chunkGetter, results, mid, to)
-                );
+                return computeLeaf();
             }
+
+            int mid = (from + to) >>> 1;
+            SpawnDataCollector left = new SpawnDataCollector(
+                entities,
+                chunkGetter,
+                from,
+                mid
+            );
+            SpawnDataCollector right = new SpawnDataCollector(
+                entities,
+                chunkGetter,
+                mid,
+                to
+            );
+            left.fork();
+            SpawnResult rightResult = right.compute();
+            SpawnResult leftResult = left.join();
+            leftResult.merge(rightResult);
+            return leftResult;
         }
 
-        private void processEntity(Entity entity) {
-            if (entity instanceof Mob mob && (mob.isPersistenceRequired() || mob.requiresCustomPersistence())) {
+        private SpawnResult computeLeaf() {
+            SpawnResult result = new SpawnResult();
+            for (int i = from; i < to; i++) {
+                processEntity(entities[i], result);
+            }
+            return result;
+        }
+
+        private void processEntity(Entity entity, SpawnResult result) {
+            if (
+                entity instanceof Mob mob &&
+                (mob.isPersistenceRequired() || mob.requiresCustomPersistence())
+            ) {
                 return;
             }
 
@@ -71,17 +115,24 @@ public final class ParallelSpawnHelper {
 
             BlockPos blockPos = entity.blockPosition();
             chunkGetter.query(ChunkPos.asLong(blockPos), chunk -> {
-                MobSpawnSettings.MobSpawnCost cost = NaturalSpawner.getRoughBiome(blockPos, chunk)
+                MobSpawnSettings.MobSpawnCost cost =
+                    NaturalSpawner.getRoughBiome(blockPos, chunk)
                         .getMobSettings()
                         .getMobSpawnCost(entity.getType());
 
-                results.add(new SpawnEntry(
-                        blockPos,
-                        category,
-                        cost != null ? cost.charge() : 0.0,
-                        entity instanceof Mob,
-                        chunk.getPos()
-                ));
+                if (cost != null) {
+                    result.charges.add(
+                        new ChargeEntry(blockPos, cost.charge())
+                    );
+                }
+
+                result.mobCounts.addTo(category, 1);
+
+                if (entity instanceof Mob) {
+                    result.mobCapEntries.add(
+                        new MobCapEntry(chunk.getPos(), category)
+                    );
+                }
             });
         }
     }

--- a/fabric/src/main/java/com/axalotl/async/fabric/mixin/utils/ClassInstanceMultiMapMixin.java
+++ b/fabric/src/main/java/com/axalotl/async/fabric/mixin/utils/ClassInstanceMultiMapMixin.java
@@ -3,6 +3,10 @@ package com.axalotl.async.fabric.mixin.utils;
 import com.axalotl.async.common.parallelised.ConcurrentCollections;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collector;
 import net.minecraft.util.ClassInstanceMultiMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -10,16 +14,13 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collector;
-
 @Mixin(value = ClassInstanceMultiMap.class)
-public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T> {
+public abstract class ClassInstanceMultiMapMixin<
+    T
+> extends AbstractCollection<T> {
 
     @Unique
-    private static final Object async$lock = new Object();
+    private final Object async$lock = new Object();
 
     @Shadow
     private final Map<Class<?>, List<T>> byClass = new ConcurrentHashMap<>();
@@ -27,8 +28,16 @@ public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T
     @Shadow
     private final List<T> allInstances = new CopyOnWriteArrayList<>();
 
-    @ModifyArg(method = "method_15217", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"))
-    private Collector<T, ?, List<T>> overwriteCollectToList(Collector<T, ?, List<T>> collector) {
+    @ModifyArg(
+        method = "method_15217",
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"
+        )
+    )
+    private Collector<T, ?, List<T>> overwriteCollectToList(
+        Collector<T, ?, List<T>> collector
+    ) {
         return ConcurrentCollections.toList();
     }
 

--- a/neoforge/src/main/java/com/axalotl/async/neoforge/mixin/utils/ClassInstanceMultiMapMixin.java
+++ b/neoforge/src/main/java/com/axalotl/async/neoforge/mixin/utils/ClassInstanceMultiMapMixin.java
@@ -3,6 +3,10 @@ package com.axalotl.async.neoforge.mixin.utils;
 import com.axalotl.async.common.parallelised.ConcurrentCollections;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collector;
 import net.minecraft.util.ClassInstanceMultiMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -10,16 +14,13 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collector;
-
 @Mixin(value = ClassInstanceMultiMap.class)
-public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T> {
+public abstract class ClassInstanceMultiMapMixin<
+    T
+> extends AbstractCollection<T> {
 
     @Unique
-    private static final Object async$lock = new Object();
+    private final Object async$lock = new Object();
 
     @Shadow
     private final Map<Class<?>, List<T>> byClass = new ConcurrentHashMap<>();
@@ -27,8 +28,16 @@ public abstract class ClassInstanceMultiMapMixin<T> extends AbstractCollection<T
     @Shadow
     private final List<T> allInstances = new CopyOnWriteArrayList<>();
 
-    @ModifyArg(method = {"lambda$find$0", "m_13537_"}, at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"))
-    private Collector<T, ?, List<T>> overwriteCollectToList(Collector<T, ?, List<T>> collector) {
+    @ModifyArg(
+        method = { "lambda$find$0", "m_13537_" },
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"
+        )
+    )
+    private Collector<T, ?, List<T>> overwriteCollectToList(
+        Collector<T, ?, List<T>> collector
+    ) {
         return ConcurrentCollections.toList();
     }
 


### PR DESCRIPTION
…pelining, and concurrency improvements

ParallelProcessor.java
- Thread detection: Replaced WeakReference-based thread tracking with ThreadLocal<Boolean> via custom AsyncTickWorkerThread subclass. isServerExecutionThread() is now O(1) instead of streaming weak references.
- Null safety: Added tickPool == null || tickPool.isShutdown() guards to callEntityTick, asyncSpawnForChunk, asyncDespawn.
- Error handling: safeTickSync() wrapper catches exceptions during synchronous fallback ticks. EntityTickBatch catches per-entity errors and auto-blacklists the entity. DespawnBatch catches per-entity errors.
- Timeout/rescue: postEntityTick wait loop has a 10s deadline. On timeout, cancels hung tasks and synchronously ticks any entities that weren't completed (tracked via boolean[] completed array).
- Spawn pipelining preserved: Spawn task is NOT joined in the wait loop - it pipelines across ticks, same as upstream.
- Spawn double-buffer: Replaced ArrayList<Runnable> with typed SpawnEntry records and a swap-buffer pattern (no drain/copy). Previous spawn task is joined rather than discarding work.
- External task queue: MpscUnboundedArrayQueue (jctools via Netty) instead of ConcurrentLinkedQueue.
- shouldTickSynchronously: Early-return chain ordered cheapest-first instead of single boolean expression.

RandomTickBatch.java (new)
- RecursiveAction for fork-join subdivision of random tick work across chunks (grain size 16). Used by ChunkMapMixin.forEachBlockTickingChunk instead of per-chunk CompletableFuture.runAsync().

EntitySectionMixin.java
- getEntities(): Removed redundant .toList().stream() copy since CopyOnWriteArrayList.stream() already iterates a snapshot.

EntitySectionStorageMixin.java
- Double-checked locking: getOrCreateSection now re-checks sections.get(pos) inside the synchronized block to avoid duplicate section creation.

NaturalSpawnerMixin.java + ParallelSpawnHelper.java
- Tree-merge pattern: SpawnDataCollector changed from RecursiveAction + shared ConcurrentLinkedQueue to RecursiveTask<SpawnResult> with local accumulation and parent-level merging. Eliminates CAS contention on shared queue.
- Selective charge recording: Only adds ChargeEntry when cost != null (upstream always added with charge=0.0).

PotentialCalculatorMixin.java
- ArrayList instead of CopyOnWriteArrayList for charges. Safe because charges are built sequentially on the main thread before being read.

ClassInstanceMultiMapMixin.java (fabric + neoforge)
- Per-instance lock (private final) instead of static lock (private static final). Sections in different chunks no longer contend on a single global lock.