### PR TITLE
Fix async mob spawning deadlock on structure_starts chunk loads

### DIFF
--- a/common/src/main/java/com/axalotl/async/common/commands/ConfigCommand.java
+++ b/common/src/main/java/com/axalotl/async/common/commands/ConfigCommand.java
@@ -30,6 +30,7 @@ public class ConfigCommand {
                 .then(buildReloadCommand())
                 .then(buildSynchronizedEntitiesCommand())
                 .then(buildAsyncEntitySpawnCommand())
+                .then(buildAsyncMobSpawningCommand())
                 .then(buildAsyncRandomTicksCommand())
         );
     }
@@ -148,6 +149,28 @@ public class ConfigCommand {
                             PlatformUtils.saveConfig();
 
                             sendMessage(ctx, "Async Random Ticks set to ",
+                                    String.valueOf(value),
+                                    true);
+                            return 1;
+                        })
+                );
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> buildAsyncMobSpawningCommand() {
+        return literal("setAsyncMobSpawning")
+                .executes(ctx -> {
+                    sendMessage(ctx, "Current value of async natural mob spawning: ",
+                            String.valueOf(AsyncConfig.enableAsyncMobSpawning),
+                            false);
+                    return 1;
+                })
+                .then(Commands.argument("value", BoolArgumentType.bool())
+                        .executes(ctx -> {
+                            boolean value = BoolArgumentType.getBool(ctx, "value");
+                            AsyncConfig.enableAsyncMobSpawning = value;
+                            PlatformUtils.saveConfig();
+
+                            sendMessage(ctx, "Async Natural Mob Spawning set to ",
                                     String.valueOf(value),
                                     true);
                             return 1;

--- a/common/src/main/java/com/axalotl/async/common/commands/StatsCommand.java
+++ b/common/src/main/java/com/axalotl/async/common/commands/StatsCommand.java
@@ -60,6 +60,7 @@ public class StatsCommand {
 
         boolean enabled = !AsyncConfig.disabled;
         boolean asyncSpawn = AsyncConfig.enableAsyncSpawn;
+        boolean asyncMobSpawning = AsyncConfig.enableAsyncMobSpawning;
         boolean asyncRandomTicks = AsyncConfig.enableAsyncRandomTicks;
 
         MutableComponent message = prefix.copy()
@@ -72,6 +73,10 @@ public class StatsCommand {
                 .append(Component.literal("\nAsync Spawn: ").withStyle(ChatFormatting.WHITE))
                 .append(Component.literal(asyncSpawn ? "Enabled" : "Disabled")
                         .withStyle(asyncSpawn ? ChatFormatting.GREEN : ChatFormatting.RED))
+
+                .append(Component.literal("\nAsync Mob Spawning: ").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(asyncMobSpawning ? "Enabled" : "Disabled")
+                        .withStyle(asyncMobSpawning ? ChatFormatting.GREEN : ChatFormatting.RED))
 
                 .append(Component.literal("\nAsync Random Ticks: ").withStyle(ChatFormatting.WHITE))
                 .append(Component.literal(asyncRandomTicks ? "Enabled" : "Disabled")

--- a/common/src/main/java/com/axalotl/async/common/config/AsyncConfig.java
+++ b/common/src/main/java/com/axalotl/async/common/config/AsyncConfig.java
@@ -16,6 +16,7 @@ public class AsyncConfig {
     public static boolean disabled = false;
     public static int maxThreads = -1;
     public static boolean enableAsyncSpawn = true;
+    public static boolean enableAsyncMobSpawning = getDefaultAsyncMobSpawning();
     public static boolean enableAsyncRandomTicks = false;
     public static Set<String> synchronizedEntities = getDefaultSynchronizedEntities();
 
@@ -32,6 +33,10 @@ public class AsyncConfig {
                 "minecraft:experience_orb"
         ));
         return defaultSynchronizedEntities;
+    }
+
+    public static boolean getDefaultAsyncMobSpawning() {
+        return !PlatformUtils.isModLoaded("c2me");
     }
 
     public static int getParallelism() {

--- a/common/src/main/java/com/axalotl/async/common/mixin/server/ServerChunkCacheMixin.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/server/ServerChunkCacheMixin.java
@@ -83,6 +83,9 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
     @Unique
     private final AtomicBoolean async$spawnCountsReady = new AtomicBoolean(false);
 
+    @Unique
+    private volatile boolean async$forceSyncMobSpawning = false;
+
     @Shadow
     public abstract void tickSpawningChunk(LevelChunk chunk, long timeInhabited, List<MobCategory> spawnCategories, NaturalSpawner.SpawnState spawnState);
 
@@ -94,6 +97,16 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
         if (access != null) {
             cir.setReturnValue(access);
             return;
+        }
+
+        if (async$isHighRiskAsyncChunkRequest(leastStatus, create)) {
+            String message = String.format(
+                    Locale.ROOT,
+                    "Blocked async chunk request that could synchronously load or generate chunks on thread %s at [%d, %d] status %s create=%s",
+                    Thread.currentThread().getName(), x, z, leastStatus, create
+            );
+            ParallelProcessor.LOGGER.warn(message);
+            throw new IllegalStateException(message);
         }
 
         CompletableFuture<ChunkResult<ChunkAccess>> future = CompletableFuture.supplyAsync(
@@ -119,6 +132,11 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
     }
 
     @Unique
+    private boolean async$isHighRiskAsyncChunkRequest(ChunkStatus leastStatus, boolean create) {
+        return create || leastStatus.isOrAfter(ChunkStatus.STRUCTURE_STARTS);
+    }
+
+    @Unique
     private @Nullable ChunkAccess async$tryGetChunk(int x, int z, ChunkStatus leastStatus) {
         ChunkHolder holder = this.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
         if (holder == null) return null;
@@ -139,8 +157,10 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
         if (Thread.currentThread() != this.mainThread) {
             final ChunkHolder holder = this.getVisibleChunkIfPresent(ChunkPos.asLong(chunkX, chunkZ));
             if (holder != null) {
-                final CompletableFuture<ChunkResult<ChunkAccess>> future = holder.scheduleChunkGenerationTask(ChunkStatus.FULL, this.chunkMap);
-                ChunkAccess chunk = future.getNow(ChunkHolder.UNLOADED_CHUNK).orElse(null);
+                ChunkAccess chunk = holder.getChunkIfPresent(ChunkStatus.FULL);
+                if (chunk instanceof ImposterProtoChunk imposter) {
+                    chunk = imposter.getWrapped();
+                }
                 if (chunk instanceof LevelChunk worldChunk) {
                     cir.setReturnValue(worldChunk);
                 }
@@ -148,9 +168,14 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
         }
     }
 
+    @Unique
+    private boolean async$canUseAsyncMobSpawning() {
+        return !AsyncConfig.disabled && AsyncConfig.enableAsyncSpawn && AsyncConfig.enableAsyncMobSpawning && !async$forceSyncMobSpawning;
+    }
+
     @Inject(method = "tickChunks()V", at = @At("TAIL"))
     private void tickChunks(CallbackInfo ci) {
-        if (AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn) return;
+        if (!async$canUseAsyncMobSpawning()) return;
 
         if (async$firstRunSpawnCounts) {
             async$firstRunSpawnCounts = false;
@@ -159,8 +184,14 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
         if (async$spawnCountsReady.getAndSet(false)) {
             final int i = distanceManager.getNaturalSpawnChunkCount();
             ParallelProcessor.tickPool.submit(() -> {
-                lastSpawnState = NaturalSpawner.createState(i, this.level.getAllEntities(), this::getFullChunk, new LocalMobCapCalculator(this.chunkMap));
-                async$spawnCountsReady.set(true);
+                try {
+                    lastSpawnState = NaturalSpawner.createState(i, this.level.getAllEntities(), this::getFullChunk, new LocalMobCapCalculator(this.chunkMap));
+                } catch (Throwable throwable) {
+                    async$forceSyncMobSpawning = true;
+                    ParallelProcessor.LOGGER.warn("Async natural spawn state calculation failed, disabling async natural mob spawning for this level", throwable);
+                } finally {
+                    async$spawnCountsReady.set(true);
+                }
             });
         }
     }
@@ -170,7 +201,7 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
         profiler.push("naturalSpawnCount");
         int i = this.distanceManager.getNaturalSpawnChunkCount();
 
-        if (AsyncConfig.disabled || !AsyncConfig.enableAsyncSpawn || async$firstRunSpawnCounts) {
+        if (!async$canUseAsyncMobSpawning() || async$firstRunSpawnCounts) {
             lastSpawnState = NaturalSpawner.createState(i, this.level.getAllEntities(), this::getFullChunk, new LocalMobCapCalculator(this.chunkMap));
         }
 
@@ -186,7 +217,7 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
 
         profiler.popPush("tickSpawningChunks");
 
-        if (!AsyncConfig.disabled && AsyncConfig.enableAsyncSpawn) {
+        if (async$canUseAsyncMobSpawning()) {
             NaturalSpawner.SpawnState currentState = lastSpawnState;
             if (currentState != null) {
                 CompletableFuture.runAsync(() -> {
@@ -199,21 +230,8 @@ public abstract class ServerChunkCacheMixin extends ChunkSource {
                         }
                     }
                 }, ParallelProcessor.tickPool).exceptionally(e -> {
-                    ParallelProcessor.LOGGER.error("Error in async entity spawning, switching to synchronous", e);
-                    List<LevelChunk> list1 = this.spawningChunks;
-                    try {
-                        profiler.popPush("filteringSpawningChunks");
-                        this.chunkMap.collectSpawningChunks(list1);
-                        profiler.popPush("shuffleSpawningChunks");
-                        Util.shuffle(list1, this.level.random);
-                        profiler.popPush("tickSpawningChunks");
-
-                        for(LevelChunk levelchunk : list1) {
-                            this.tickSpawningChunk(levelchunk, timeInhabited, list, lastSpawnState);
-                        }
-                    } finally {
-                        list1.clear();
-                    }
+                    async$forceSyncMobSpawning = true;
+                    ParallelProcessor.LOGGER.error("Error in async natural mob spawning, disabling async natural mob spawning for this level", e);
                     return null;
                 });
             }

--- a/fabric/src/main/java/com/axalotl/async/fabric/config/AsyncConfig.java
+++ b/fabric/src/main/java/com/axalotl/async/fabric/config/AsyncConfig.java
@@ -28,6 +28,7 @@ public class AsyncConfig {
             "maxThreads",
             "synchronizedEntities",
             "enableAsyncSpawn",
+            "enableAsyncMobSpawning",
             "enableAsyncRandomTicks"
     );
 
@@ -63,6 +64,8 @@ public class AsyncConfig {
                           - 'minecraft:*'      = all entities in namespace""");
         setWithComment("enableAsyncSpawn", enableAsyncSpawn,
                 "Enables async entity spawning. WARNING: incompatible with Carpet's lagFreeSpawning.");
+        setWithComment("enableAsyncMobSpawning", enableAsyncMobSpawning,
+                "Enables async natural mob spawning. Defaults to false when C2ME is detected to avoid chunk-load deadlocks.");
         setWithComment("enableAsyncRandomTicks", enableAsyncRandomTicks,
                 "Experimental! Enables async random ticks.");
 
@@ -81,6 +84,7 @@ public class AsyncConfig {
         disabled = CONFIG.getOrElse("disabled", disabled);
         maxThreads = CONFIG.getOrElse("maxThreads", maxThreads);
         enableAsyncSpawn = CONFIG.getOrElse("enableAsyncSpawn", enableAsyncSpawn);
+        enableAsyncMobSpawning = CONFIG.getOrElse("enableAsyncMobSpawning", enableAsyncMobSpawning);
         enableAsyncRandomTicks = CONFIG.getOrElse("enableAsyncRandomTicks", enableAsyncRandomTicks);
 
         List<String> entries = CONFIG.get("synchronizedEntities");
@@ -100,6 +104,7 @@ public class AsyncConfig {
                   - 'minecraft:zombie' = specific entity
                   - 'minecraft:*'      = all entities in namespace""");
         setCommentIfExists("enableAsyncSpawn", "Enables async entity spawning. WARNING: incompatible with Carpet's lagFreeSpawning.");
+        setCommentIfExists("enableAsyncMobSpawning", "Enables async natural mob spawning. Defaults to false when C2ME is detected to avoid chunk-load deadlocks.");
         setCommentIfExists("enableAsyncRandomTicks", "Experimental! Enables async random ticks.");
     }
 
@@ -129,6 +134,7 @@ public class AsyncConfig {
         disabled = false;
         maxThreads = -1;
         enableAsyncSpawn = true;
+        enableAsyncMobSpawning = getDefaultAsyncMobSpawning();
         enableAsyncRandomTicks = false;
         synchronizedEntities = getDefaultSynchronizedEntities();
     }

--- a/neoforge/src/main/java/com/axalotl/async/neoforge/config/AsyncConfig.java
+++ b/neoforge/src/main/java/com/axalotl/async/neoforge/config/AsyncConfig.java
@@ -17,6 +17,7 @@ public class AsyncConfig {
     private static final ModConfigSpec.IntValue maxThreads;
     private static final ModConfigSpec.ConfigValue<List<? extends String>> synchronizedEntities;
     private static final ModConfigSpec.BooleanValue enableAsyncSpawn;
+    private static final ModConfigSpec.BooleanValue enableAsyncMobSpawning;
     private static final ModConfigSpec.BooleanValue enableAsyncRandomTicks;
 
     static {
@@ -42,6 +43,9 @@ public class AsyncConfig {
         enableAsyncSpawn = BUILDER.comment("Enables async entity spawning. WARNING: incompatible with Carpet's lagFreeSpawning.")
                 .define("enableAsyncSpawn", com.axalotl.async.common.config.AsyncConfig.enableAsyncSpawn);
 
+        enableAsyncMobSpawning = BUILDER.comment("Enables async natural mob spawning. Defaults to false when C2ME is detected to avoid chunk-load deadlocks.")
+                .define("enableAsyncMobSpawning", com.axalotl.async.common.config.AsyncConfig.enableAsyncMobSpawning);
+
         enableAsyncRandomTicks = BUILDER.comment("Experimental! Enables async random ticks.")
                 .define("enableAsyncRandomTicks", com.axalotl.async.common.config.AsyncConfig.enableAsyncRandomTicks);
 
@@ -54,6 +58,7 @@ public class AsyncConfig {
         com.axalotl.async.common.config.AsyncConfig.disabled = disabled.get();
         com.axalotl.async.common.config.AsyncConfig.maxThreads = maxThreads.get();
         com.axalotl.async.common.config.AsyncConfig.enableAsyncSpawn = enableAsyncSpawn.get();
+        com.axalotl.async.common.config.AsyncConfig.enableAsyncMobSpawning = enableAsyncMobSpawning.get();
         com.axalotl.async.common.config.AsyncConfig.enableAsyncRandomTicks = enableAsyncRandomTicks.get();
 
         List<? extends String> entries = synchronizedEntities.get();
@@ -71,6 +76,7 @@ public class AsyncConfig {
         disabled.set(com.axalotl.async.common.config.AsyncConfig.disabled);
         maxThreads.set(com.axalotl.async.common.config.AsyncConfig.maxThreads);
         enableAsyncSpawn.set(com.axalotl.async.common.config.AsyncConfig.enableAsyncSpawn);
+        enableAsyncMobSpawning.set(com.axalotl.async.common.config.AsyncConfig.enableAsyncMobSpawning);
         enableAsyncRandomTicks.set(com.axalotl.async.common.config.AsyncConfig.enableAsyncRandomTicks);
         synchronizedEntities.set(new ArrayList<>(com.axalotl.async.common.config.AsyncConfig.synchronizedEntities));
         SPEC.save();


### PR DESCRIPTION
I ran into a server hang where multiple Async-Tick-Pool-Threads were stuck on Sync load chunk to status minecraft:structure_starts in world minecraft:overworld, and the server was killed by watchdog after about one minute.

The original implementation had two problems:
`tickChunksSpawn()` could run natural mob spawning on the async pool
non-main-thread `async$getChunk()` could still reach create=true or high-risk chunk states such as structure_starts, which could make async workers wait for main-thread chunk loading
That creates a wait cycle: async worker threads wait for chunk loading, while the server thread can end up waiting for async worker completion.

This PR changes that behavior by:
adding `enableAsyncMobSpawning` as a separate config option
defaulting async natural mob spawning to disabled when C2ME is detected via `getDefaultAsyncMobSpawning()`
blocking unsafe async chunk requests in `async$getChunk()`
making `shortcutGetChunkNow()` only read already-loaded FULL chunks instead of triggering generation from worker threads
forcing natural mob spawning to fall back to synchronous execution when async spawning becomes unsafe in `tickChunksSpawn()`
