### PR TITLE
fix LithiumServerLevel mixin

### DIFF
--- a/common/src/main/java/com/axalotl/async/common/mixin/lithium/LithiumServerLevel.java
+++ b/common/src/main/java/com/axalotl/async/common/mixin/lithium/LithiumServerLevel.java
@@ -43,7 +43,7 @@ public abstract class LithiumServerLevel extends Level implements WorldGenLevel,
                     target = "Ljava/util/Set;iterator()Ljava/util/Iterator;"
             )
     )
-    private void updateActiveListeners(BlockPos pos, BlockState old, BlockState current, int updateFlags, CallbackInfo ci, @Local(name = "navigationsToUpdate") List<PathNavigation> navigationsToUpdate) {
+    private void updateActiveListeners(BlockPos pos, BlockState old, BlockState current, int updateFlags, CallbackInfo ci, @Local(ordinal = 0) List<PathNavigation> navigationsToUpdate) {
         for (PathNavigation nav : async$activeNavigationsOver) {
             if (nav.shouldRecomputePath(pos)) {
                 navigationsToUpdate.add(nav);


### PR DESCRIPTION
oops!

Lithium on 1.21.1 captures the PathNavigation list via list position not by name.